### PR TITLE
build: add css files for icons and flags

### DIFF
--- a/packages/apps/builder/.config/webpack.config.js
+++ b/packages/apps/builder/.config/webpack.config.js
@@ -11,6 +11,12 @@ module.exports = merge(baseConfig, {
       './src/oui.js',
       './src/oui.less',
     ],
+    'oui-flags': [
+      './src/oui-flags.less',
+    ],
+    'oui-icons': [
+      './src/oui-icons.less',
+    ],
   },
   output: {
     filename: '[name].js',

--- a/packages/apps/builder/package.json
+++ b/packages/apps/builder/package.json
@@ -16,8 +16,8 @@
     "build:webpack": "cross-env NODE_ENV=production webpack --progress --colors --config ./.config/webpack.config.js",
     "clean": "rimraf ./dist ../../../dist ../../libs/ui-kit/dist",
     "copy": "run-p copy:*",
-    "copy:root": "cpx \"./dist/**/*\" \"../../../dist\"",
-    "copy:lib": "cpx \"./dist/**/*\" \"../../libs/ui-kit/dist\"",
+    "copy:root": "cpx \"./dist/**/!(oui-flags.j*|oui-icons.j*)\" \"../../../dist\"",
+    "copy:lib": "cpx \"./dist/**/!(oui-flags.j*|oui-icons.j*)\" \"../../libs/ui-kit/dist\"",
     "prepare": "yarn build"
   },
   "dependencies": {

--- a/packages/apps/builder/src/oui-flags.less
+++ b/packages/apps/builder/src/oui-flags.less
@@ -1,0 +1,7 @@
+/*!
+ * @ovh-ux/ui-kit.flags
+ */
+
+@rem-base: rem-base(16px);
+
+@import '~@ovh-ux/ui-kit.core/src/oui-flags';

--- a/packages/apps/builder/src/oui-icons.less
+++ b/packages/apps/builder/src/oui-icons.less
@@ -1,0 +1,7 @@
+/*!
+ * @ovh-ux/ui-kit.icons
+ */
+
+@rem-base: rem-base(16px);
+
+@import '~@ovh-ux/ui-kit.core/src/oui-icons';

--- a/packages/base/core/src/index.less
+++ b/packages/base/core/src/index.less
@@ -1,5 +1,3 @@
-@import './less/_legacy';
-@import './less/_tokens';
 @import './less/_variables';
 @import './less/_mixins';
 @import './less/reboot';

--- a/packages/base/core/src/less/_variables.less
+++ b/packages/base/core/src/less/_variables.less
@@ -1,3 +1,6 @@
+@import './_legacy';
+@import './_tokens';
+
 /* Generated */
 @import './variables/generated/flags';
 @import './variables/generated/icons';

--- a/packages/base/core/src/oui-flags.less
+++ b/packages/base/core/src/oui-flags.less
@@ -1,0 +1,3 @@
+@import './less/_variables';
+@import './less/_mixins';
+@import './less/flags';

--- a/packages/base/core/src/oui-icons.less
+++ b/packages/base/core/src/oui-icons.less
@@ -1,0 +1,3 @@
+@import './less/_variables';
+@import './less/_mixins';
+@import './less/icons';


### PR DESCRIPTION
Create `oui-icons.css` and `oui-flags.css` in the `/dist` files.
So we can use them regardless of the main `oui.css`.

Since Webpack create 2 empty `.js` and `.js.map` files, they are excluded when we copy them from the builder app.