### PR TITLE
build: remove sourcemap on dist files

### DIFF
--- a/packages/base/config/src/webpack.dist.config.js
+++ b/packages/base/config/src/webpack.dist.config.js
@@ -6,7 +6,6 @@ const { cssExtractLoader } = require('./webpack.rules');
 
 module.exports = merge(baseConfig, {
   mode: 'production',
-  devtool: 'source-map',
   performance: {
     hints: false,
   },

--- a/packages/base/config/src/webpack.rules.js
+++ b/packages/base/config/src/webpack.rules.js
@@ -75,12 +75,11 @@ const styleLoader = {
   test: /\.css|.less$/,
   use: [
     { loader: 'style-loader' },
-    { loader: 'css-loader', options: { sourceMap: true } },
+    { loader: 'css-loader' },
     {
       loader: 'postcss-loader',
       options: {
         ident: 'postcss',
-        sourceMap: true,
         plugins: () => [
           autoprefixer(),
           cssnano({ preset: 'default' }),
@@ -91,7 +90,6 @@ const styleLoader = {
       loader: 'less-loader',
       options: {
         plugins: [RemcalcPlugin],
-        sourceMap: true,
       },
     },
   ],


### PR DESCRIPTION
Related to https://github.com/ovh/ovh-ui-kit-bs/pull/96
- Remove the sourcemaps generated with the `dist` files.