### PR TITLE
fix(oui.input): replace fix of flex issue on firefox

### DIFF
--- a/packages/components/input/src/less/input-group.less
+++ b/packages/components/input/src/less/input-group.less
@@ -9,7 +9,7 @@
 
   .oui-input {
     min-width: 0; // Cancel min-width on firefox
-    flex: 1;
+    flex: 1 1 auto;
   }
 
   .oui-button,


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

Change the fix for flex issue on firefox.
`min-width: 0` was reducing input length to 0.

ref: MANAGER-5412
