### PR TITLE
fix(pagination): fix selector calculation checks

### DIFF
--- a/packages/components/pagination/src/js/pagination.component.js
+++ b/packages/components/pagination/src/js/pagination.component.js
@@ -8,7 +8,7 @@ export default {
     currentOffset: '<',
     pageSize: '<?',
     pageSizeMax: '<?',
-    totalItems: '<?',
+    totalItems: '<',
     onChange: '&',
   },
   controller,

--- a/packages/components/pagination/src/js/pagination.controller.js
+++ b/packages/components/pagination/src/js/pagination.controller.js
@@ -130,7 +130,7 @@ export default class {
   }
 
   updatePaginationSelectors(pageSize) {
-    if (pageSize) {
+    if (pageSize && this.currentOffset && this.totalItems) {
       // PageSize selector
       this.currentPageSize = pageSize || this.pageSize;
       this.pageSizeList = this.getPageSizeList();


### PR DESCRIPTION
When the mandatory are not set at the same time, it causes errors.
I've added checks before the calculations.

Closes #MANAGER-5393
Closes #MANAGER-5395