### PR TITLE
feat(datagrid): allow to go to given page

### DIFF
--- a/packages/components/datagrid/README.md
+++ b/packages/components/datagrid/README.md
@@ -29,6 +29,7 @@ angular.module('myModule', ['oui.datagrid'])
 | ----                              | ----      | ----      | ----                | ----             | ----         | ----
 | `id`                              | string    | @?        | no                  | n/a              | n/a          | id of the datagrid
 | `page-size`                       | number    | @?        | no                  | n/a              | `25`         | maximum number of rows to show on each pages
+| `page`                            | number    | @?        | no                  | n/a               | `1`         | page to display 
 | `rows`                            | array     | <?        | yes                 | n/a              | n/a          | local rows to load in the datagrid
 | `empty-placeholder`               | string    | @?        | yes                 | n/a              | n/a          | custom placeholder text when there is no data
 | `selectable-rows`                 | boolean   | <?        | no                  | `true`, `false`  | `false`      | allow rows to be selected. Create a sticky column a the start of the datagrid.

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -45,6 +45,8 @@ export default class DatagridController {
     this.pageSize = parseInt(this.pageSize, 10) || this.config.pageSize;
     this.filterableColumns = [];
     this.criteria = this.criteria || [];
+    this.page = parseInt(this.page, 10) || 1;
+    this.offset = (this.page - 1) * this.pageSize + 1;
 
     addBooleanParameter(this, 'selectableRows');
     addDefaultParameter(this, 'emptyPlaceholder', this.config.translations.emptyPlaceholder);
@@ -78,12 +80,13 @@ export default class DatagridController {
       this.paging = this.ouiDatagridPaging.createRemote(
         this.columns,
         builtColumns.currentSorting,
+        this.offset,
         this.pageSize,
         this.rowLoader,
         this.rowsLoader,
       );
       this.refreshData(() => {
-        this.paging.setOffset(1);
+        this.paging.setOffset(this.offset);
         this.paging.setCriteria(this.criteria);
         this.appliedCriteria = this.criteria;
       });
@@ -91,6 +94,7 @@ export default class DatagridController {
       this.paging = this.ouiDatagridPaging.createLocal(
         this.columns,
         builtColumns.currentSorting,
+        this.offset,
         this.pageSize,
         this.rowLoader,
         this.rows,

--- a/packages/components/datagrid/src/js/datagrid.directive.js
+++ b/packages/components/datagrid/src/js/datagrid.directive.js
@@ -12,6 +12,7 @@ export default () => {
       columnsDescription: '<?columns',
       columnsParameters: '<?',
       customizable: '<?',
+      page: '@?',
       pageSize: '@?',
       rows: '<?',
       rowsLoader: '&?',

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -1298,6 +1298,26 @@ describe('ouiDatagrid', () => {
       expect(getCell($secondRow, 1).children().html()).toBe(fakeData[3].lastName);
     });
 
+    it('should go to the given page', () => {
+      const element = TestUtils.compileTemplate(`
+                    <oui-datagrid rows="$ctrl.rows" page-size="2" page="2">
+                        <oui-datagrid-column property="firstName"></oui-datagrid-column>
+                        <oui-datagrid-column property="lastName"></oui-datagrid-column>
+                    </oui-datagrid>
+                `, {
+        rows: fakeData.slice(0, 5),
+      });
+
+      const $firstRow = getRow(element, 0);
+      const $secondRow = getRow(element, 1);
+
+      expect(getCell($firstRow, 0).children().html()).toBe(fakeData[2].firstName);
+      expect(getCell($firstRow, 1).children().html()).toBe(fakeData[2].lastName);
+
+      expect(getCell($secondRow, 0).children().html()).toBe(fakeData[3].firstName);
+      expect(getCell($secondRow, 1).children().html()).toBe(fakeData[3].lastName);
+    });
+
     it('should execute callback when pagination changes', () => {
       const onPageChangeSpy = jasmine.createSpy('onPaginationChangeSpy');
       const element = TestUtils.compileTemplate(`

--- a/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
@@ -2,8 +2,8 @@ import DatagridPagingAbstract from './datagrid-paging-abstract';
 import Filter from '../filter/filter';
 
 export default class DatagridLocalPaging extends DatagridPagingAbstract {
-  constructor(columns, currentSorting, pageSize, rowLoader, pagingService, rows) {
-    super(columns, currentSorting, pageSize, rowLoader, pagingService);
+  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService, rows) {
+    super(columns, currentSorting, offset, pageSize, rowLoader, pagingService);
 
     this.setRows(rows);
   }

--- a/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
@@ -1,10 +1,10 @@
 export default class DatagridPagingAbstract {
-  constructor(columns, currentSorting, pageSize, rowLoader, pagingService) {
+  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService) {
     this.columns = columns;
     this.currentSorting = currentSorting;
     this.criteria = [];
     this.pageSize = pageSize;
-    this.offset = 1;
+    this.offset = offset;
     this.rowLoader = rowLoader;
 
     this.$q = pagingService.$q;

--- a/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
@@ -10,11 +10,19 @@ export default class {
     this.orderByFilter = orderByFilter;
   }
 
-  createLocal(columns, sorting, pageSize, rowLoader, rows) {
-    return new DatagridLocalPaging(columns, sorting, pageSize, rowLoader, this, rows);
+  createLocal(columns, sorting, offset, pageSize, rowLoader, rows) {
+    return new DatagridLocalPaging(columns, sorting, offset, pageSize, rowLoader, this, rows);
   }
 
-  createRemote(columns, sorting, pageSize, rowLoader, rowsLoader) {
-    return new DatagridRemotePaging(columns, sorting, pageSize, rowLoader, this, rowsLoader);
+  createRemote(columns, sorting, offset, pageSize, rowLoader, rowsLoader) {
+    return new DatagridRemotePaging(
+      columns,
+      sorting,
+      offset,
+      pageSize,
+      rowLoader,
+      this,
+      rowsLoader,
+    );
   }
 }

--- a/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
@@ -1,8 +1,8 @@
 import DatagridPagingAbstract from './datagrid-paging-abstract';
 
 export default class DatagridRemotePaging extends DatagridPagingAbstract {
-  constructor(columns, currentSorting, pageSize, rowLoader, pagingService, rowsLoader) {
-    super(columns, currentSorting, pageSize, rowLoader, pagingService);
+  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService, rowsLoader) {
+    super(columns, currentSorting, offset, pageSize, rowLoader, pagingService);
 
     this.rowsLoader = rowsLoader;
   }


### PR DESCRIPTION
## Oui-datagrid: allow to go to given page


### Description of the Change

Add a `page` binding on `oui-datagrid` component to allow to set current page 

### Benefits

This is helpful when we need to set page number as it is given through URL for instance (helps for bookmarking) and avoid updating `ouiDatagridService` directly 

### Possible Drawbacks



### Applicable Issues


