### PR TITLE
feat(datagrid): allow to pass criteria

### DIFF
--- a/packages/components/datagrid/README.md
+++ b/packages/components/datagrid/README.md
@@ -31,6 +31,7 @@ angular.module('myModule', ['oui.datagrid'])
 | `page-size`                       | number    | @?        | no                  | n/a              | `25`         | maximum number of rows to show on each pages
 | `page`                            | number    | @?        | no                  | n/a               | `1`         | page to display 
 | `rows`                            | array     | <?        | yes                 | n/a              | n/a          | local rows to load in the datagrid
+| `criteria`                        | array     | <?        | yes                 | n/a              | n/a          | default filter criteria to apply
 | `empty-placeholder`               | string    | @?        | yes                 | n/a              | n/a          | custom placeholder text when there is no data
 | `selectable-rows`                 | boolean   | <?        | no                  | `true`, `false`  | `false`      | allow rows to be selected. Create a sticky column a the start of the datagrid.
 | `on-criteria-change`              | function  | &         | no                  | n/a              | n/a          | triggered when criteria changed. Use `$criteria` in your callback to get the result

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -75,10 +75,12 @@ export default class DatagridController {
 
     const builtColumns = this.buildColumns();
     this.previousRows = angular.copy(this.rows);
+    this.appliedCriteria = this.criteria;
 
     if (this.rowsLoader) {
       this.paging = this.ouiDatagridPaging.createRemote(
         this.columns,
+        this.criteria,
         builtColumns.currentSorting,
         this.offset,
         this.pageSize,
@@ -88,11 +90,11 @@ export default class DatagridController {
       this.refreshData(() => {
         this.paging.setOffset(this.offset);
         this.paging.setCriteria(this.criteria);
-        this.appliedCriteria = this.criteria;
       });
     } else {
       this.paging = this.ouiDatagridPaging.createLocal(
         this.columns,
+        this.criteria,
         builtColumns.currentSorting,
         this.offset,
         this.pageSize,

--- a/packages/components/datagrid/src/js/datagrid.directive.js
+++ b/packages/components/datagrid/src/js/datagrid.directive.js
@@ -11,6 +11,7 @@ export default () => {
       id: '@?',
       columnsDescription: '<?columns',
       columnsParameters: '<?',
+      criteria: '<?',
       customizable: '<?',
       page: '@?',
       pageSize: '@?',

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -1404,6 +1404,24 @@ describe('ouiDatagrid', () => {
       expect(element.text()).toContain('PLACEHOLDER');
     });
 
+    it('should apply default criteria', () => {
+      const element = TestUtils.compileTemplate(`
+                    <oui-datagrid rows="$ctrl.rows" criteria="[{'property': 'firstName', 'operator': 'is', 'value': 'Keith'}]">
+                        <oui-datagrid-column property="firstName" type="string" filterable></oui-datagrid-column>
+                        <oui-datagrid-column property="lastName"></oui-datagrid-column>
+                    </oui-datagrid>
+                `, {
+        rows: fakeData.slice(0, 5),
+      });
+
+      const $rows = getRows(element);
+      const $firstRow = getRow(element, 0);
+
+      expect(getCell($firstRow, 0).children().html()).toBe(fakeData[2].firstName);
+      expect(getCell($firstRow, 1).children().html()).toBe(fakeData[2].lastName);
+      expect($rows.length).toBe(1);
+    });
+
     describe('Columns', () => {
       it('should support dataset notation', () => {
         const element = TestUtils.compileTemplate(`

--- a/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
@@ -2,8 +2,8 @@ import DatagridPagingAbstract from './datagrid-paging-abstract';
 import Filter from '../filter/filter';
 
 export default class DatagridLocalPaging extends DatagridPagingAbstract {
-  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService, rows) {
-    super(columns, currentSorting, offset, pageSize, rowLoader, pagingService);
+  constructor(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService, rows) {
+    super(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService);
 
     this.setRows(rows);
   }

--- a/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
@@ -1,8 +1,8 @@
 export default class DatagridPagingAbstract {
-  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService) {
+  constructor(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService) {
     this.columns = columns;
     this.currentSorting = currentSorting;
-    this.criteria = [];
+    this.criteria = criteria;
     this.pageSize = pageSize;
     this.offset = offset;
     this.rowLoader = rowLoader;

--- a/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
@@ -10,13 +10,23 @@ export default class {
     this.orderByFilter = orderByFilter;
   }
 
-  createLocal(columns, sorting, offset, pageSize, rowLoader, rows) {
-    return new DatagridLocalPaging(columns, sorting, offset, pageSize, rowLoader, this, rows);
+  createLocal(columns, criteria, sorting, offset, pageSize, rowLoader, rows) {
+    return new DatagridLocalPaging(
+      columns,
+      criteria,
+      sorting,
+      offset,
+      pageSize,
+      rowLoader,
+      this,
+      rows,
+    );
   }
 
-  createRemote(columns, sorting, offset, pageSize, rowLoader, rowsLoader) {
+  createRemote(columns, criteria, sorting, offset, pageSize, rowLoader, rowsLoader) {
     return new DatagridRemotePaging(
       columns,
+      criteria,
       sorting,
       offset,
       pageSize,

--- a/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
@@ -1,8 +1,17 @@
 import DatagridPagingAbstract from './datagrid-paging-abstract';
 
 export default class DatagridRemotePaging extends DatagridPagingAbstract {
-  constructor(columns, currentSorting, offset, pageSize, rowLoader, pagingService, rowsLoader) {
-    super(columns, currentSorting, offset, pageSize, rowLoader, pagingService);
+  constructor(
+    columns,
+    criteria,
+    currentSorting,
+    offset,
+    pageSize,
+    rowLoader,
+    pagingService,
+    rowsLoader,
+  ) {
+    super(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService);
 
     this.rowsLoader = rowsLoader;
   }


### PR DESCRIPTION
### Requirements

## Oui-datagrid: allow to pass criteria

### Description of the Change

Allow to pass criteria that correspond to the current filters being applied to the daat

### Benefits

This allow to have pre-filtered datagrid 

### Possible Drawbacks


### Applicable Issues

