### PR TITLE
docs: add changelog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Once you have `yarn start`-ed the project, you can edit anything with an automat
 
 Documentation is available from the `packages/` folder, every package is self-documented throught a `README.md` file.
 
+## Changelog
+
+For full Changelog, visit <https://ovh.github.io/ovh-ui-kit/?path=/docs/documentation-changelog--page>.
+
 ## Related links
 
  * Contribute: [https://github.com/ovh/ovh-ui-kit/blob/master/CONTRIBUTING.md](https://github.com/ovh/ovh-ui-kit/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## Add changelog URL

### Description of the Change

#### :books: Documentation

docs: add changelog URL

### Benefits

We can reach the changelog also via the `README.md` file.
It avoid to launch the GitHub Page (Storybook UI and the go on `Changelog` page.)

### Possible Drawbacks

None.

### Applicable Issues

None.


Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>