### PR TITLE
fix(oui.tile): inherit oui tile button line height

### DIFF
--- a/packages/components/tile/src/less/tile.less
+++ b/packages/components/tile/src/less/tile.less
@@ -27,6 +27,7 @@
     border-radius: 0;
     text-align: left;
     text-decoration: none;
+    line-height: inherit;
 
     &.oui-button_block.oui-button_icon-right {
       .oui-icon {


### PR DESCRIPTION
ref: MANAGER-5417
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

Setting `line-height` attribute to inherit, for `oui-tile_button` class