### PR TITLE
fix(datagrid): convert typeOptions to a string to be able to parse it

### DIFF
--- a/packages/components/datagrid/src/js/datagrid-column-builder.service.js
+++ b/packages/components/datagrid/src/js/datagrid-column-builder.service.js
@@ -43,7 +43,7 @@ export default class DatagridColumnBuilder {
         name: description.name || getAttribute(element, 'name'),
         preventCustomization: description.preventCustomization || hasAttribute(element, 'prevent-customization'),
         type: description.type || getAttribute(element, 'type') || 'string',
-        typeOptions: description.typeOptions || description['type-options'] || getAttribute(element, 'type-options'),
+        typeOptions: JSON.stringify(description.typeOptions) || description['type-options'] || getAttribute(element, 'type-options'),
       };
 
       const propertyValue = description.property || getAttribute(element, 'property');


### PR DESCRIPTION
## Oui-datagrid: convert typeOptions to a string to be able to parse it


### Description of the Change

Stringify type-options if they are set through the dynamic columns options

### Benefits

This allow to pass options as an object instead of a string when using dynamic columns configuraiton
