### PR TITLE
fix(header): change detection for scroll right

### DIFF
--- a/packages/components/header/src/js/tabs/header-tabs.controller.js
+++ b/packages/components/header/src/js/tabs/header-tabs.controller.js
@@ -12,7 +12,7 @@ export default class {
 
   checkScroll() {
     this.$timeout(() => {
-      this.canScroll = this.tabsList.clientWidth < this.tabsList.scrollWidth;
+      this.canScroll = this.tabsList.clientWidth < this.initialScrollWidth;
 
       // Reset scroll value
       this.canScrollLeft = false;
@@ -38,8 +38,9 @@ export default class {
       this.scrollIndex = Math.min(this.scrollIndex + 1, maxIndex);
     }
 
+    this.canScrollRight = (this.getOffsetLeft() + this.tabsList.clientWidth)
+      <= this.initialScrollWidth;
     this.canScrollLeft = this.scrollIndex > minIndex;
-    this.canScrollRight = this.scrollIndex < maxIndex;
 
     // The slide animation is done in the CSS with a transition
     // targeting the margin-left property n the first child.
@@ -70,6 +71,8 @@ export default class {
         // eslint-disable-next-line
         element.initialOffsetLeft = element.offsetLeft;
       });
+
+      this.initialScrollWidth = this.tabsList.scrollWidth;
 
       this.$scope.$watch(() => this.tabsList.childNodes.length, () => {
         this.tabs = filter(this.tabsList.childNodes, (node) => node.nodeType === 1);


### PR DESCRIPTION
Signed-off-by: jjuret <julien.juret@gmail.com>

## Limit scroll right on header


### Description of the Change

i've change detection by index for a detection if have space to scroll.

### Benefits

result is morre natural

Before : 
![before](https://user-images.githubusercontent.com/14954832/94832914-cec4f680-040e-11eb-8e2a-dea9a0f4a9bc.png)

After :
![after](https://user-images.githubusercontent.com/14954832/94832951-d7b5c800-040e-11eb-91f8-fd74a0775551.png)

