### PR TITLE
fix(header): change detection for scroll right

### DIFF
--- a/packages/components/header/src/js/tabs/header-tabs.controller.js
+++ b/packages/components/header/src/js/tabs/header-tabs.controller.js
@@ -12,7 +12,7 @@ export default class {
 
   checkScroll() {
     this.$timeout(() => {
-      this.canScroll = this.tabsList.clientWidth < this.tabsList.scrollWidth;
+      this.canScroll = this.tabsList.clientWidth < this.initialScrollWidth;
 
       // Reset scroll value
       this.canScrollLeft = false;
@@ -38,8 +38,9 @@ export default class {
       this.scrollIndex = Math.min(this.scrollIndex + 1, maxIndex);
     }
 
+    this.canScrollRight = (this.getOffsetLeft() + this.tabsList.clientWidth)
+      <= this.initialScrollWidth;
     this.canScrollLeft = this.scrollIndex > minIndex;
-    this.canScrollRight = this.scrollIndex < maxIndex;
 
     // The slide animation is done in the CSS with a transition
     // targeting the margin-left property n the first child.
@@ -70,6 +71,8 @@ export default class {
         // eslint-disable-next-line
         element.initialOffsetLeft = element.offsetLeft;
       });
+
+      this.initialScrollWidth = this.tabsList.scrollWidth;
 
       this.$scope.$watch(() => this.tabsList.childNodes.length, () => {
         this.tabs = filter(this.tabsList.childNodes, (node) => node.nodeType === 1);


### PR DESCRIPTION
## Limit scroll right on header

### Description of the Change

i've change detection by index for a detection if have space to scroll.

### Benefits

result is more natural

Before :
![before](https://user-images.githubusercontent.com/14954832/94835260-c3bf9580-0411-11eb-81c7-128600c51f78.png)

After :
![after](https://user-images.githubusercontent.com/14954832/94835282-c8844980-0411-11eb-9da1-f0578c765a4b.png)

