### PR TITLE
Back button - pass full sentence

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/back-button/back-button-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/back-button/back-button-webcomponent.stories.js
@@ -37,6 +37,22 @@ export const Simple = forModule(moduleName).createElement(
   ),
 );
 
+export const Default = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-back-button
+      href="#"
+      aria-label="Aria label for heading"
+      on-click="$ctrl.onClick()">
+    </oui-back-button>`,
+    {
+      $ctrl: {
+        onClick: action('onClick'),
+      },
+    },
+  ),
+);
+
 export const WithHeading = forModule(moduleName).createElement(
   () => compileTemplate(
     `

--- a/packages/components/back-button/README.md
+++ b/packages/components/back-button/README.md
@@ -14,7 +14,8 @@ angular.module('myModule', ['oui.field'])
     // default translations
     ouiBackButtonConfigurationProvider.setTranslations({
       backTo: 'Back to',
-      previousPage: 'Previous page',
+      backToPreviousPage: 'Back to Previous page',
+      previousPage: 'Previous page', //Deprecated
     });
   });
 ```

--- a/packages/components/back-button/src/js/back-button.controller.js
+++ b/packages/components/back-button/src/js/back-button.controller.js
@@ -31,7 +31,7 @@ export default class {
   getBtnText() {
     return this.previousPage
       ? `${this.translations.backTo} “${this.previousPage}”`
-      : `${this.translations.backTo} “${this.translations.previousPage}”`;
+      : this.translations.backToPreviousPage || `${this.translations.backTo} ${this.translations.previousPage}`;
   }
 
   // Return value of "ui-sref"

--- a/packages/components/back-button/src/js/back-button.provider.js
+++ b/packages/components/back-button/src/js/back-button.provider.js
@@ -4,7 +4,8 @@ export default class {
   constructor() {
     this.translations = {
       backTo: 'Back to',
-      previousPage: 'Previous page',
+      previousPage: 'Previous page', // Deprecated
+      backToPreviousPage: 'Back to “Previous page“',
     };
   }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

##  allow to pass full translated sentence instead of leaving the concatenation to component


### Description of the Change

Instead of concatenating the "back to" and "previous page" by default allow to pass full sentence

### Benefits

This will work in every language we want 
e.g: French

### Possible Drawbacks

None

### Applicable Issues

e.g: in french it would be 'Retour à la "page précédente"' but we will also have 'Retour à la "Lorem Ipsum"' if we keep it that way 
