### PR TITLE
fix(field): allow to check if status is invalid outside of a form

### DIFF
--- a/packages/components/field/src/js/field.controller.js
+++ b/packages/components/field/src/js/field.controller.js
@@ -154,7 +154,7 @@ export default class FieldController {
   checkAllErrors() {
     this.invalid = Object.keys(this.controls)
       .map((name) => {
-        if (!this.form && !(name in this.form)) {
+        if (!this.form || !(name in this.form)) {
           return false;
         }
         if (this.form[name].$invalid && !this.currentErrorField) {


### PR DESCRIPTION
## fix(field): a missing field couldn't be invalid

### Description of the Change

If there is no form, or if a field is no more present in the form, we
can't check if it's invalid.

### Benefits

Avoid `TypeError: Cannot read property '$invalid' of undefined` error in console.


