### PR TITLE
fix(typography): add default pointer-event property on links

### DIFF
--- a/packages/base/core/src/less/mixins/typography.less
+++ b/packages/base/core/src/less/mixins/typography.less
@@ -55,6 +55,7 @@
     text-decoration: @text-decoration;
     cursor: pointer;
     -webkit-text-decoration-skip: objects;
+    pointer-events: auto;
 
     &:active,
     &:hover {


### PR DESCRIPTION
## Add default pointer-events property on oui-link


### Description of the Change

Add `pointer-events: auto` to oui-link style

### Benefits

This allow to keep the link clickable if the value gets overwritten 
e.g: In a disabled select-picker

<img width="246" alt="Capture d’écran 2020-10-20 à 11 57 04" src="https://user-images.githubusercontent.com/14836007/96571188-8a20d280-12cb-11eb-83a4-732a4e224967.png">

### Possible Drawbacks


### Applicable Issues


