### PR TITLE
fix(oui-tile): always use on-click binding

### DIFF
--- a/packages/components/tile/src/js/button/tile-button.html
+++ b/packages/components/tile/src/js/button/tile-button.html
@@ -14,7 +14,8 @@
     ng-href="{{:: $ctrl.href }}"
     ng-attr-rel="{{:: $ctrl.external ? 'noopener' : undefined }}"
     ng-attr-target="{{:: $ctrl.external ? '_blank' : undefined }}"
-    ng-attr-aria-label="{{ :: $ctrl.ariaLabel }}">
+    ng-attr-aria-label="{{ :: $ctrl.ariaLabel }}"
+    ng-click="$ctrl.onClick()">
     <span ng-transclude></span>
     <span class="oui-icon oui-icon-external-link"
           aria-hidden="true"

--- a/packages/components/tile/src/js/tile.spec.js
+++ b/packages/components/tile/src/js/tile.spec.js
@@ -108,6 +108,7 @@ describe('ouiTile', () => {
 
     it('should handle click in a button tile', () => {
       const clickSpy = jasmine.createSpy('click');
+      const hrefClickSpy = jasmine.createSpy('click');
       const element = TestUtils.compileTemplate(
         `<oui-tile>
             <oui-tile-button on-click="$ctrl.clickSpy()">text</oui-tile-button>
@@ -116,8 +117,19 @@ describe('ouiTile', () => {
         },
       );
 
+      const elementWithHref = TestUtils.compileTemplate(
+        `<oui-tile>
+            <oui-tile-button href="#" on-click="$ctrl.hrefClickSpy()">text</oui-tile-button>
+        </oui-tile>`, {
+          hrefClickSpy,
+        },
+      );
+
       getTileButton(element).triggerHandler('click');
       expect(clickSpy).toHaveBeenCalled();
+
+      getTileButton(elementWithHref).triggerHandler('click');
+      expect(hrefClickSpy).toHaveBeenCalled();
     });
 
     it('should disable the button', () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## oui-tile-button : always use on-click binding


### Description of the Change

Use on-click binding even if href is defined 

### Benefits

<!-- optional -->
<!-- What benefits will be achieved by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
