### PR TITLE
fix(oui-stepper): prevent focusing on steps on destroy

### DIFF
--- a/packages/components/stepper/src/js/stepper.controller.js
+++ b/packages/components/stepper/src/js/stepper.controller.js
@@ -103,4 +103,8 @@ export default class {
       }
     });
   }
+
+  $onDestroy() {
+    this.steps = [];
+  }
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->

Prevent onFocus from being triggered on steps when leaving a page/route

### Description of the Change

Add onDestroy hook so actions on steps are no longer executed when stepper is being destroyed

### Benefits


### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

ref: DTRSD-27753
