### PR TITLE
feat(datagrid): allow to align with columns in expanded row

### DIFF
--- a/packages/components/datagrid/README.md
+++ b/packages/components/datagrid/README.md
@@ -128,6 +128,25 @@ The template inside the element will be placed at the bottom of each row, making
 </oui-datagrid>
 ```
 
+As many row details can be added as needed 
+
+```html
+<oui-datagrid rows="$ctrl.data">
+    <oui-datagrid-column title="'FirstName'">
+        <span ng-bind="$row.firstName"></span>
+    </oui-datagrid-column>
+    <oui-datagrid-column title="'LastName'">
+        <span ng-bind="$row.lastName"></span>
+    </oui-datagrid-column>
+    <oui-datagrid-row-detail>
+        <a href="mailto:{{$row.email}}">{{$row.email}}</a>
+    </oui-datagrid-row-detail>
+    <oui-datagrid-row-detail>
+        <span ng-bind="$row.birth"></span>
+    </oui-datagrid-row-detail>
+</oui-datagrid>
+```
+
 ### Attribute `on-row-select`
 
 When `selectable-rows` is provided, you can listen to checkboxes changes with the `on-row-select` event. It provides `$row` as the triggered row and `$rows` as the complete list of rows selected so far.

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -168,7 +168,7 @@ export default class DatagridController {
     }
 
     if (this.expandableRows) {
-      this.rowDetailCompiledTemplate = this.$compile(`<div>${this.rowDetailElements[0].innerHTML}</div>`);
+      this.rowDetailCompiledTemplates = this.rowDetailElements.map((rowDetail) => this.$compile(`<div>${rowDetail.innerHTML}</div>`));
     }
 
     this.availableColumns = angular.copy(builtColumns.columns)

--- a/packages/components/datagrid/src/js/datagrid.html
+++ b/packages/components/datagrid/src/js/datagrid.html
@@ -143,12 +143,11 @@
             <tr class="oui-datagrid-row-detail"
                 ng-repeat-end
                 ng-show="$ctrl.isRowExpanded($index)">
-                <td class="oui-datagrid__cell oui-datagrid__cell_s"
-                    ng-if="$ctrl.selectableRows">
-                </td>
+                <td class="oui-datagrid__cell oui-datagrid__cell_s"></td>
                 <td class="oui-datagrid-row-detail__cell"
-                    ng-attr-colspan="{{ $ctrl.columns.length + 1 + ($ctrl.selectableRows ? 1 : 0) }}">
-                    <oui-datagrid-row-detail class="oui-datagrid-row-detail__container" row="row">
+                    ng-repeat="rowDetail in $ctrl.rowDetailElements track by $index"
+                    ng-attr-colspan="{{$last ? $ctrl.columns.length - $ctrl.rowDetailElements.length + 1 : 1}}">
+                    <oui-datagrid-row-detail class="oui-datagrid-row-detail__container" row="row" index="$index">
                     </oui-datagrid-row-detail>
                 </td>
             </tr>

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -578,6 +578,34 @@ describe('ouiDatagrid', () => {
         ctrl.toggleRowExpansion(0);
         expect(ctrl.expandedRows.length).toEqual(0);
       });
+      it('should have as many columns in expanded row than in parent', () => {
+        const element = TestUtils.compileTemplate(`
+            <oui-datagrid rows="$ctrl.rows">
+                <oui-datagrid-column property="firstName"></oui-datagrid-column>
+                <oui-datagrid-column property="lastName"></oui-datagrid-column>
+                <oui-datagrid-row-detail>
+                  <span>Email : <span ng-bind="$row.email"></span>
+              </oui-datagrid-row-detail>
+              <oui-datagrid-row-detail>
+                  <span>Email : <span ng-bind="$row.phone"></span>
+              </oui-datagrid-row-detail>
+            </oui-datagrid>
+          `, {
+          rows: fakeData.slice(0, 5),
+        });
+
+        const ctrl = element.controller('ouiDatagrid');
+        expect(ctrl.expandableRows).toBe(true);
+        expect(ctrl.expandedRows.length).toEqual(0);
+        ctrl.toggleRowExpansion(0);
+        expect(ctrl.expandedRows.length).toEqual(1);
+        expect(ctrl.isRowExpanded(0)).toBe(true);
+        expect(element.find('<span ng-bind="$row.email>')).not.toBe(null);
+        expect(element.find('<span ng-bind="$row.phone>')).not.toBe(null);
+        ctrl.toggleRowExpansion(0);
+        expect(ctrl.expandedRows.length).toEqual(0);
+        expect(ctrl.isRowExpanded(0)).toBe(false);
+      });
     });
 
     describe('Remote rows', () => {

--- a/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.component.js
+++ b/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.component.js
@@ -7,5 +7,6 @@ export default {
   },
   bindings: {
     row: '<',
+    index: '<',
   },
 };

--- a/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.controller.js
+++ b/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.controller.js
@@ -14,7 +14,7 @@ export default class {
     this.rowDetailScope.$row = this.row;
     this.copyRow = angular.copy(this.row);
 
-    this.datagridCtrl.rowDetailCompiledTemplate(this.rowDetailScope, (clone) => {
+    this.datagridCtrl.rowDetailCompiledTemplates[this.index](this.rowDetailScope, (clone) => {
       this.$element.empty();
       this.$element.append(clone);
     });

--- a/packages/components/datagrid/src/less/datagrid.less
+++ b/packages/components/datagrid/src/less/datagrid.less
@@ -55,7 +55,6 @@ oui-datagrid {
   &__container {
     display: block;
     color: @oui-datagrid-cell-font-color;
-    margin-left: @oui-datagrid-row-detail-spacing;
     padding: @oui-datagrid-row-detail-padding;
   }
 }


### PR DESCRIPTION
Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Allow to have values for each columns in an expanded column


### Description of the Change

Allow to add multiple `row-detail` component to fit on needed columns

### Benefits

This allow to match all given columns if wanted

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
