### PR TITLE
docs(workshop): set iframeHeight to docs pages

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/action-menu/action-menu-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/action-menu/action-menu-webcomponent.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Action Menu/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/back-button/back-button-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/back-button/back-button-webcomponent.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Back Button/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/box/box-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/box/box-native.stories.js
@@ -4,6 +4,7 @@ export default {
   title: 'Design System/Components/Box/Native',
 
   parameters: {
+    docs: { iframeHeight: 250 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-native-ghost.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-native-ghost.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Buttons/Native/Ghost',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-native-primary.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-native-primary.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Buttons/Native/Primary',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-native-secondary.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-native-secondary.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Buttons/Native/Secondary',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-ghost.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-ghost.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Buttons/WebComponent/Ghost',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-primary.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-primary.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Buttons/WebComponent/Primary',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-secondary.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/button/button-webcomponent-secondary.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Buttons/WebComponent/Secondary',
 
   parameters: {
+    docs: { iframeHeight: 150 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/calendar/calendar-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/calendar/calendar-webcomponent.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Calendar/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 450 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/checkbox/checkbox-webcomponent-thumbnail.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/checkbox/checkbox-webcomponent-thumbnail.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Checkbox/WebComponent/Thumbnail',
 
   parameters: {
+    docs: { iframeHeight: 350 },
     notes: readme,
   },
 };
@@ -187,18 +188,8 @@ export const Validation = forModule(moduleName).createElement(
             disabled="$ctrl.disabled"
             thumbnail
             required>
-            <oui-checkbox-label>64 GB RAM</oui-checkbox-label>
-            <oui-checkbox-footer>Pellentesque habitant morbi tristique</oui-checkbox-footer>
-          </oui-checkbox>
-
-          <oui-checkbox
-            name="oui-checkbox-3"
-            model="$ctrl.model3"
-            disabled="$ctrl.disabled"
-            thumbnail
-            required>
             <oui-checkbox-label>
-              128 GB RAM
+              64 GB RAM
               <span class="oui-badge oui-badge_new">New</span>
             </oui-checkbox-label>
             <oui-checkbox-footer>Pellentesque habitant morbi tristique</oui-checkbox-footer>
@@ -213,7 +204,6 @@ export const Validation = forModule(moduleName).createElement(
         disabled: boolean('Disabled state', false),
         model1: true,
         model2: undefined,
-        model3: undefined,
         onChange: action('onChange'),
       },
     },

--- a/packages/apps/workshop/stories/design-system/components/chips/chips-webcomponent-stacked.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/chips/chips-webcomponent-stacked.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Chips/WebComponent/Stacked',
 
   parameters: {
+    docs: { iframeHeight: 250 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/collapsible/collapsible-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/collapsible/collapsible-webcomponent.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Collapsible/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 300 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/criteria/criteria-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/criteria/criteria-webcomponent.stories.js
@@ -23,6 +23,7 @@ export default {
   title: 'Design System/Components/Criteria/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 350 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
@@ -26,6 +26,7 @@ export default {
   title: 'Design System/Components/Datagrid/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 400 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/dropdown/dropdown-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/dropdown/dropdown-webcomponent.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Dropdown/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 320 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/dual-list/dual-list-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/dual-list/dual-list-webcomponent.stories.js
@@ -17,6 +17,7 @@ export default {
   title: 'Design System/Components/Dual List/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 450 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/field/field-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/field/field-webcomponent.stories.js
@@ -19,6 +19,7 @@ export default {
   title: 'Design System/Components/Field/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/File/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/guide-menu/guide-menu-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/guide-menu/guide-menu-webcomponent.stories.js
@@ -20,6 +20,7 @@ export default {
   title: 'Design System/Components/Guide Menu/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 300 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/header/header-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/header/header-webcomponent.stories.js
@@ -21,6 +21,7 @@ export default {
   title: 'Design System/Components/Header/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/inline-adder/inline-adder-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/inline-adder/inline-adder-webcomponent.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Inline Adder/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 280 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/input/input-native-group.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/input/input-native-group.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Input/Native/Group',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/input/input-native-overlay.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/input/input-native-overlay.stories.js
@@ -29,6 +29,7 @@ export default {
   title: 'Design System/Components/Input/Native/Overlay',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/input/input-native-simple.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/input/input-native-simple.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Input/Native/Simple',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/message/message-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/message/message-native.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Components/Message/Native',
 
   parameters: {
+    docs: { iframeHeight: 350 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/message/message-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/message/message-webcomponent.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Message/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 350 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/modal/modal-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/modal/modal-webcomponent.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Modal/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 400 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/navbar/navbar-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/navbar/navbar-native.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Components/Navbar/Native',
 
   parameters: {
+    docs: { iframeHeight: 350 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/navbar/navbar-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/navbar/navbar-webcomponent.stories.js
@@ -27,6 +27,7 @@ export default {
   title: 'Design System/Components/Navbar/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 350 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/numeric/numeric-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/numeric/numeric-webcomponent.stories.js
@@ -23,6 +23,7 @@ export default {
   title: 'Design System/Components/Numeric/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 180 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/password/password-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/password/password-webcomponent.stories.js
@@ -24,6 +24,7 @@ export default {
   title: 'Design System/Components/Password/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 180 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/progress-tracker/progress-tracker-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/progress-tracker/progress-tracker-native.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Components/Progress Tracker/Native',
 
   parameters: {
+    docs: { iframeHeight: 300 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/progress/progress-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/progress/progress-native.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Components/Progress/Native',
 
   parameters: {
+    docs: { iframeHeight: 180 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
@@ -13,6 +13,7 @@ export default {
   title: 'Design System/Components/Progress/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 220 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/radio/radio-webcomponent-simple.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/radio/radio-webcomponent-simple.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Radio/WebComponent/Simple',
 
   parameters: {
+    docs: { iframeHeight: 250 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/radio/radio-webcomponent-thumbnail.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/radio/radio-webcomponent-thumbnail.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Radio/WebComponent/Thumbnail',
 
   parameters: {
+    docs: { iframeHeight: 350 },
     notes: readme,
   },
 };
@@ -200,17 +201,8 @@ export const Validation = forModule(moduleName).createElement(
             value="$ctrl.value2"
             thumbnail
             required>
-            <oui-radio-label>64 GB RAM</oui-radio-label>
-            <oui-radio-footer>Pellentesque habitant morbi tristique</oui-radio-footer>
-          </oui-radio>
-
-          <oui-radio
-            disabled="$ctrl.disabled"
-            value="$ctrl.value3"
-            thumbnail
-            required>
             <oui-radio-label>
-              128 GB RAM
+              64 GB RAM
               <span class="oui-badge oui-badge_new">New</span>
             </oui-radio-label>
             <oui-radio-footer>Pellentesque habitant morbi tristique</oui-radio-footer>
@@ -227,7 +219,6 @@ export const Validation = forModule(moduleName).createElement(
         model: undefined,
         value1: '32',
         value2: '64',
-        value3: '128',
         onChange: action('onChange'),
       },
     },

--- a/packages/apps/workshop/stories/design-system/components/search/search-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/search/search-webcomponent.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Search/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/select-picker/select-picker-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/select-picker/select-picker-webcomponent.stories.js
@@ -25,6 +25,7 @@ export default {
   title: 'Design System/Components/Select Picker/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 650 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/select/select-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/select/select-native.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Select/Native',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/select/select-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/select/select-webcomponent.stories.js
@@ -24,6 +24,7 @@ export default {
   title: 'Design System/Components/Select/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/sidebar/sidebar-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/sidebar/sidebar-native.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Components/Sidebar/Native',
 
   parameters: {
+    docs: { iframeHeight: 400 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/skeleton/skeleton-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/skeleton/skeleton-webcomponent.stories.js
@@ -12,6 +12,7 @@ export default {
   title: 'Design System/Components/Skeleton/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/slideshow/slideshow-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/slideshow/slideshow-webcomponent.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Components/Slideshow/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 600 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/spinner/spinner-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/spinner/spinner-webcomponent.stories.js
@@ -12,6 +12,7 @@ export default {
   title: 'Design System/Components/Spinner/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 300 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/stepper/stepper-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/stepper/stepper-webcomponent.stories.js
@@ -25,6 +25,7 @@ export default {
   title: 'Design System/Components/Stepper/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 850 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/switch/switch-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/switch/switch-webcomponent.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Switch/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 200 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/table/table-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/table/table-native.stories.js
@@ -7,6 +7,7 @@ export default {
   title: 'Design System/Components/Table/Native',
 
   parameters: {
+    docs: { iframeHeight: 350 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/components/tabs/tabs-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/tabs/tabs-webcomponent.stories.js
@@ -13,6 +13,7 @@ export default {
   title: 'Design System/Components/Tabs/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 280 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/textarea/textarea-native.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/textarea/textarea-native.stories.js
@@ -16,6 +16,7 @@ export default {
   title: 'Design System/Components/Textarea/Native',
 
   parameters: {
+    docs: { iframeHeight: 600 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/textarea/textarea-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/textarea/textarea-webcomponent.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Textarea/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 300 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/tile/tile-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/tile/tile-webcomponent.stories.js
@@ -22,6 +22,7 @@ export default {
   title: 'Design System/Components/Tile/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 520 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/components/timepicker/timepicker-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/timepicker/timepicker-webcomponent.stories.js
@@ -14,6 +14,7 @@ export default {
   title: 'Design System/Components/Timepicker/WebComponent',
 
   parameters: {
+    docs: { iframeHeight: 300 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/content/descriptions.stories.js
+++ b/packages/apps/workshop/stories/design-system/content/descriptions.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Content/Descriptions',
 
   parameters: {
+    docs: { iframeHeight: 370 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/content/headings.stories.js
+++ b/packages/apps/workshop/stories/design-system/content/headings.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Content/Headings',
 
   parameters: {
+    docs: { iframeHeight: 420 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/content/icons.stories.js
+++ b/packages/apps/workshop/stories/design-system/content/icons.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Content/Icons',
 
   parameters: {
+    docs: { iframeHeight: 600 },
     options: {
       showPanel: false,
     },

--- a/packages/apps/workshop/stories/design-system/content/list.stories.js
+++ b/packages/apps/workshop/stories/design-system/content/list.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Content/List',
 
   parameters: {
+    docs: { iframeHeight: 500 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/content/paragraphs.stories.js
+++ b/packages/apps/workshop/stories/design-system/content/paragraphs.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Content/Paragraphs',
 
   parameters: {
+    docs: { iframeHeight: 130 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/directives/autocomplete/autocomplete.stories.js
+++ b/packages/apps/workshop/stories/design-system/directives/autocomplete/autocomplete.stories.js
@@ -15,6 +15,7 @@ export default {
   title: 'Design System/Directives/Autocomplete',
 
   parameters: {
+    docs: { iframeHeight: 150 },
   },
 };
 

--- a/packages/apps/workshop/stories/design-system/directives/popover/popover.stories.js
+++ b/packages/apps/workshop/stories/design-system/directives/popover/popover.stories.js
@@ -33,6 +33,7 @@ export default {
   title: 'Design System/Directives/Popover',
 
   parameters: {
+    docs: { iframeHeight: 130 },
     notes: readme,
   },
 };

--- a/packages/apps/workshop/stories/design-system/helpers/backgrounds.stories.js
+++ b/packages/apps/workshop/stories/design-system/helpers/backgrounds.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Helpers/Backgrounds',
 
   parameters: {
+    docs: { iframeHeight: 400 },
     options: {
       showPanel: false,
     },

--- a/packages/apps/workshop/stories/design-system/helpers/colors.stories.js
+++ b/packages/apps/workshop/stories/design-system/helpers/colors.stories.js
@@ -2,6 +2,7 @@ export default {
   title: 'Design System/Helpers/Colors',
 
   parameters: {
+    docs: { iframeHeight: 400 },
     options: {
       showPanel: false,
     },


### PR DESCRIPTION
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

## DocsPage iFrame heights

### Description of the Change

For "Docs" tab in Storybook, setting iframe heights to avoid scrolling to get details of each story

Example with `oui-datagrid`:

Switching from

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/34273689/111494344-ab80d000-873e-11eb-9c6c-6b065e478790.png">

to

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/34273689/111494223-960ba600-873e-11eb-8e4d-fa246b201d9f.png">
