### PR TITLE
feat(progress-bar): add new UI to component

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
@@ -58,6 +58,18 @@ export const Stacked = forModule(moduleName).createElement(
   ),
 );
 
+export const Sizes = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-progress size="m">
+      <oui-progress-bar type="info" value="50"></oui-progress-bar>
+    </oui-progress>
+    <oui-progress size="l">
+      <oui-progress-bar type="info" value="50"></oui-progress-bar>
+    </oui-progress>`,
+  ),
+);
+
 export const WithThresholds = forModule(moduleName).createElement(
   () => compileTemplate(
     `

--- a/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/progress/progress-webcomponent.stories.js
@@ -117,6 +117,29 @@ export const WithCustomLabel = forModule(moduleName).createElement(
 
 WithCustomLabel.storyName = 'With custom label';
 
+export const WithoutLabels = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-progress no-labels>
+      <oui-progress-bar value="7.5"></oui-progress-bar>
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar>
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar>
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar>
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar>
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+      <oui-progress-bar value="7.5"></oui-progress-bar> 
+    </oui-progress>`,
+  ),
+);
+
+WithoutLabels.storyName = 'Without labels';
+
 export const Compact = forModule(moduleName).createElement(
   () => compileTemplate(
     `

--- a/packages/base/core/src/less/tokens/_colors.less
+++ b/packages/base/core/src/less/tokens/_colors.less
@@ -77,3 +77,18 @@
 @delivery-24-hours: #268403;
 @delivery-72-hours: #b6c511;
 @delivery-10-days: #ffc800;
+
+// Chart color suite
+@chart-color-1: @p-800;                     // #00185e
+@chart-color-2: @p-400;                     // #157eea
+@chart-color-3: @product-new;               // #47fffa
+@chart-color-4: #008686;                    // #008686
+@chart-color-5: @delivery-72-hours;         // #95d326
+@chart-color-6: @product-beta;              // #7cffb0
+@chart-color-7: @promotion-500;             // #ac246f
+@chart-color-8: @product-limited-edition;   // #ff4400
+@chart-color-9: @product-price-drop;        // #ffce0d
+@chart-color-10: @product-alpha;            // #fbff47
+@chart-color-11: @p-900;                    // #000d9b
+@chart-color-12: @p-800-text;               // #4d5592
+@chart-color-13: @p-100;                    // #bef1ff

--- a/packages/base/core/src/less/variables/components/progress.less
+++ b/packages/base/core/src/less/variables/components/progress.less
@@ -18,7 +18,6 @@
 @oui-progress-threshold-foreground: rgba(100, 100, 100, 0.3);
 
 // Progress - Variants
-@oui-progress-info-foreground-color: @p-500;
 @oui-progress-success-foreground-color: @as-500;
 @oui-progress-warning-foreground-color: @aw-400;
 @oui-progress-error-foreground-color: @ae-500;

--- a/packages/base/core/src/less/variables/components/progress.less
+++ b/packages/base/core/src/less/variables/components/progress.less
@@ -18,8 +18,8 @@
 @oui-progress-threshold-foreground: rgba(100, 100, 100, 0.3);
 
 @oui-progress-segment-colors: @chart-color-1, @chart-color-2, @chart-color-3, @chart-color-4, @chart-color-5,
-                              @chart-color-6, @chart-color-7, @chart-color-8, @chart-color-9, @chart-color-10,
-                              @chart-color-11, @chart-color-12, @chart-color-13;
+  @chart-color-6, @chart-color-7, @chart-color-8, @chart-color-9, @chart-color-10, @chart-color-11, @chart-color-12,
+  @chart-color-13;
 
 // Progress - Variants
 @oui-progress-success-foreground-color: @as-500;

--- a/packages/base/core/src/less/variables/components/progress.less
+++ b/packages/base/core/src/less/variables/components/progress.less
@@ -1,6 +1,7 @@
 // Progress
 @oui-progress-height: rem-calc(10);
 @oui-progress-height_compact: rem-calc(16);
+@oui-progress-height_size-l: rem-calc(16);
 @oui-progress-margin: @base-spacing-small 0;
 @oui-progress-background-color: @g-100;
 

--- a/packages/base/core/src/less/variables/components/progress.less
+++ b/packages/base/core/src/less/variables/components/progress.less
@@ -17,6 +17,10 @@
 @oui-progress-threshold-background: @p-000;
 @oui-progress-threshold-foreground: rgba(100, 100, 100, 0.3);
 
+@oui-progress-segment-colors: @chart-color-1, @chart-color-2, @chart-color-3, @chart-color-4, @chart-color-5,
+                              @chart-color-6, @chart-color-7, @chart-color-8, @chart-color-9, @chart-color-10,
+                              @chart-color-11, @chart-color-12, @chart-color-13;
+
 // Progress - Variants
 @oui-progress-success-foreground-color: @as-500;
 @oui-progress-warning-foreground-color: @aw-400;

--- a/packages/components/progress/README.md
+++ b/packages/components/progress/README.md
@@ -10,11 +10,11 @@ angular.module('myModule', ['oui.progress']);
 
 | Attribute     | Type      | Binding   | One-time binding  | Values                                | default       | Description
 | ----          | ----      | ----      | ----              | ----                                  | ----          | ----
-| `size`        | string    | @?        | yes               | `m` (default), `l`                                   | `0`           | min value of progress component
+| `size`        | string    | @?        | yes               | `m`, `l`                              | `m`           | expected size of component
 | `min-value`   | number    | @?        | yes               | n/a                                   | `0`           | min value of progress component
 | `max-value`   | number    | @?        | yes               | n/a                                   | `100`         | max value of progress component
 | `compact`     | boolean   | <?        | yes               | `true`, `false`                       | `false`       | compact mode flag
-| `no-labels`   | boolean   | <?        | yes               | `true`, `false`                       | `false`       | compact mode flag
+| `no-labels`   | boolean   | <?        | yes               | `true`, `false`                       | `false`       | removing segment labels or not 
 
 ## Component `oui-progress-bar`
 | Attribute     | Type      | Binding | One-time binding    | Values                                | default       | Description

--- a/packages/components/progress/README.md
+++ b/packages/components/progress/README.md
@@ -10,9 +10,11 @@ angular.module('myModule', ['oui.progress']);
 
 | Attribute     | Type      | Binding   | One-time binding  | Values                                | default       | Description
 | ----          | ----      | ----      | ----              | ----                                  | ----          | ----
+| `size`        | string    | @?        | yes               | `m` (default), `l`                                   | `0`           | min value of progress component
 | `min-value`   | number    | @?        | yes               | n/a                                   | `0`           | min value of progress component
 | `max-value`   | number    | @?        | yes               | n/a                                   | `100`         | max value of progress component
 | `compact`     | boolean   | <?        | yes               | `true`, `false`                       | `false`       | compact mode flag
+| `no-labels`   | boolean   | <?        | yes               | `true`, `false`                       | `false`       | compact mode flag
 
 ## Component `oui-progress-bar`
 | Attribute     | Type      | Binding | One-time binding    | Values                                | default       | Description

--- a/packages/components/progress/src/js/bar/progress-bar.controller.js
+++ b/packages/components/progress/src/js/bar/progress-bar.controller.js
@@ -13,6 +13,7 @@ export default class {
   $onInit() {
     addDefaultParameter(this, 'type', 'info');
 
+    this.size = this.progressCtrl.size;
     this.compact = this.progressCtrl.compact;
     this.minValue = this.progressCtrl.minValue;
     this.maxValue = this.progressCtrl.maxValue;

--- a/packages/components/progress/src/js/bar/progress-bar.controller.js
+++ b/packages/components/progress/src/js/bar/progress-bar.controller.js
@@ -15,6 +15,7 @@ export default class {
 
     this.size = this.progressCtrl.size;
     this.compact = this.progressCtrl.compact;
+    this.noLabels = this.progressCtrl.noLabels;
     this.minValue = this.progressCtrl.minValue;
     this.maxValue = this.progressCtrl.maxValue;
   }

--- a/packages/components/progress/src/js/bar/progress-bar.html
+++ b/packages/components/progress/src/js/bar/progress-bar.html
@@ -1,1 +1,3 @@
-<span class="oui-progress__label" ng-transclude>{{$ctrl.value + '%'}}</span>
+<span class="oui-progress__label"
+      ng-if="!$ctrl.noLabels"
+      ng-transclude>{{$ctrl.value + '%'}}</span>

--- a/packages/components/progress/src/js/progress.component.js
+++ b/packages/components/progress/src/js/progress.component.js
@@ -3,6 +3,7 @@ import controller from './progress.controller';
 export default {
   controller,
   bindings: {
+    size: '@?',
     compact: '<?',
     minValue: '@?',
     maxValue: '@?',

--- a/packages/components/progress/src/js/progress.component.js
+++ b/packages/components/progress/src/js/progress.component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     size: '@?',
     compact: '<?',
+    noLabels: '<?',
     minValue: '@?',
     maxValue: '@?',
   },

--- a/packages/components/progress/src/js/progress.controller.js
+++ b/packages/components/progress/src/js/progress.controller.js
@@ -12,6 +12,7 @@ export default class {
   $onInit() {
     addBooleanParameter(this, 'size');
     addBooleanParameter(this, 'compact');
+    addBooleanParameter(this, 'noLabels');
     addDefaultParameter(this, 'minValue', '0');
     addDefaultParameter(this, 'maxValue', '100');
   }
@@ -26,6 +27,10 @@ export default class {
 
       if (this.compact) {
         this.$element.addClass('oui-progress_compact');
+      }
+
+      if (this.noLabels) {
+        this.$element.addClass('oui-progress_no-labels');
       }
     });
   }

--- a/packages/components/progress/src/js/progress.controller.js
+++ b/packages/components/progress/src/js/progress.controller.js
@@ -10,6 +10,7 @@ export default class {
   }
 
   $onInit() {
+    addBooleanParameter(this, 'size');
     addBooleanParameter(this, 'compact');
     addDefaultParameter(this, 'minValue', '0');
     addDefaultParameter(this, 'maxValue', '100');
@@ -18,6 +19,10 @@ export default class {
   $postLink() {
     this.$timeout(() => {
       this.$element.addClass('oui-progress');
+
+      if (this.size) {
+        this.$element.addClass(`oui-progress_size-${this.size}`);
+      }
 
       if (this.compact) {
         this.$element.addClass('oui-progress_compact');

--- a/packages/components/progress/src/js/progress.spec.js
+++ b/packages/components/progress/src/js/progress.spec.js
@@ -55,6 +55,17 @@ describe('ouiProgress', () => {
       expect(element.hasClass(`${progressClass}_compact`)).toBeTruthy();
     });
 
+    it('should display a progress bar without labels', () => {
+      const element = TestUtils.compileTemplate(`
+                <oui-progress compact>
+                    <oui-progress-bar value="50"></oui-progress-bar>
+                </oui-progress>`);
+
+      $timeout.flush();
+
+      expect(element.hasClass(`${progressClass}_no-labels`)).toBeTruthy();
+    });
+
     it('should set type info by default', () => {
       const element = TestUtils.compileTemplate(`
                 <oui-progress>

--- a/packages/components/progress/src/less/progress.less
+++ b/packages/components/progress/src/less/progress.less
@@ -166,14 +166,6 @@
       border-radius: (@oui-progress-height / 2);
     }
 
-    &_info {
-      color: @oui-progress-info-foreground-color;
-
-      &::-webkit-progress-value { background-color: @oui-progress-info-foreground-color; }
-      &::-moz-progress-bar { background-color: @oui-progress-info-foreground-color; }
-      &::-ms-fill { background-color: @oui-progress-info-foreground-color; }
-    }
-
     &_success {
       color: @oui-progress-success-foreground-color;
 
@@ -199,6 +191,14 @@
     }
   }
 }
+
+.segment-colors(@i: length(@oui-progress-segment-colors)) when (@i > 0) {
+    .oui-progress__bar_info:nth-of-type(@{i})::before {
+        @name: extract(@oui-progress-segment-colors, @i);
+        background-color: @name;
+    }
+    .segment-colors((@i - 1));
+} .segment-colors;
 
 oui-progress {
   &,

--- a/packages/components/progress/src/less/progress.less
+++ b/packages/components/progress/src/less/progress.less
@@ -193,12 +193,15 @@
 }
 
 .segment-colors(@i: length(@oui-progress-segment-colors)) when (@i > 0) {
-    .oui-progress__bar_info:nth-of-type(@{i})::before {
-        @name: extract(@oui-progress-segment-colors, @i);
-        background-color: @name;
-    }
-    .segment-colors((@i - 1));
-} .segment-colors;
+  .oui-progress__bar_info:nth-of-type(@{i})::before {
+    @name: extract(@oui-progress-segment-colors, @i);
+
+    background-color: @name;
+  }
+  .segment-colors((@i - 1));
+}
+
+.segment-colors;
 
 oui-progress {
   &,

--- a/packages/components/progress/src/less/progress.less
+++ b/packages/components/progress/src/less/progress.less
@@ -141,12 +141,6 @@
     }
   }
 
-  &_no-labels {
-    .oui-progress__label {
-      display: none;
-    }
-  }
-
   // Native progress support
   progress& {
     height: @oui-progress-height;

--- a/packages/components/progress/src/less/progress.less
+++ b/packages/components/progress/src/less/progress.less
@@ -44,8 +44,6 @@
       border-bottom-right-radius: (@oui-progress-height / 2);
     }
 
-    &_info::before { background-color: @oui-progress-info-foreground-color; }
-
     &_success::before { background-color: @oui-progress-success-foreground-color; }
 
     &_warning::before { background-color: @oui-progress-warning-foreground-color; }
@@ -112,6 +110,34 @@
 
     .oui-progress__threshold {
       display: none;
+    }
+  }
+
+  &_size-l {
+    &::before {
+      border-radius: (@oui-progress-height_size-l / 2);
+    }
+
+    &::before,
+    .oui-progress__bar::before {
+      height: @oui-progress-height_size-l;
+    }
+
+    .oui-progress__bar {
+      &::before {
+        border-top-left-radius: (@oui-progress-height_size-l / 2);
+        border-bottom-left-radius: (@oui-progress-height_size-l / 2);
+      }
+
+      & ~ .oui-progress__bar::before {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+
+      &:last-of-type::before {
+        border-top-right-radius: (@oui-progress-height_size-l / 2);
+        border-bottom-right-radius: (@oui-progress-height_size-l / 2);
+      }
     }
   }
 

--- a/packages/components/progress/src/less/progress.less
+++ b/packages/components/progress/src/less/progress.less
@@ -141,6 +141,12 @@
     }
   }
 
+  &_no-labels {
+    .oui-progress__label {
+      display: none;
+    }
+  }
+
   // Native progress support
   progress& {
     height: @oui-progress-height;


### PR DESCRIPTION
## Title of the Pull Requests <!-- required -->
Adding new UI to component

### Description of the Change
Following the global UI bump of our components, here we are adding multiple things :
- a global color scheme for charts, in order to present chart segments in a cohesive way
- regarding the color scheme, the `<oui-progress-bar>` now follows the chart color scheme for its "Stacked" usage
- a new size `size="l"` for a wide `<oui-progress-bar>`
- and also a `no-labels` attribute that hides labels on `<oui-progress-bar>` so that it can be handled elsewhere

### Benefits
For future chart developments, we already have the color range to use, and also a new UI for `<oui-progress-bar>`

### Possible Drawbacks
Since the default `<oui-progress-bar>` type is always `info`, we are now overriding the current `info` colors for "Stacked" `<oui-progress-bar>` data
