### PR TITLE
fix(config): prevent processing svg as html

### DIFF
--- a/packages/base/config/src/webpack.rules.js
+++ b/packages/base/config/src/webpack.rules.js
@@ -58,7 +58,7 @@ const babelLoader = {
 };
 
 const htmlLoader = {
-  test: /\.(html|svg)$/,
+  test: /\.(html)$/,
   use: [
     {
       loader: 'html-loader',


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Prevent processing svg as html

### Description of the Change

Don't process svgs as html 

### Applicable Issues

fix #696
