### PR TITLE
fix(oui.navbar): remove vulnerable ng-bind-html

### DIFF
--- a/packages/components/navbar/src/js/dropdown/navbar-dropdown.html
+++ b/packages/components/navbar/src/js/dropdown/navbar-dropdown.html
@@ -19,7 +19,7 @@
                 ng-bind="$ctrl.iconBadge">
             </span>
         </span>
-        <span class="oui-navbar-link__text" ng-bind-html="::$ctrl.text"></span>
+        <span class="oui-navbar-link__text" ng-bind="$ctrl.text"></span>
     </span>
 </button>
 <div class="oui-navbar-menu__wrapper" ng-transclude></div>

--- a/packages/components/navbar/src/js/menu/navbar-menu.html
+++ b/packages/components/navbar/src/js/menu/navbar-menu.html
@@ -50,7 +50,7 @@
             ng-href="{{::menuLink.url}}"
             oui-navbar-group="{{::$ctrl.menuName}}"
             oui-navbar-group-last="::$last">
-            <span ng-bind-html="::menuLink.title"></span>
+            <span ng-bind="::menuLink.title"></span>
             <span class="oui-icon oui-icon-external-link" aria-hidden="true"
                 ng-if="::!!menuLink.isExternal">
             </span>
@@ -66,7 +66,7 @@
                 'oui-navbar_desktop-only': !!menuLink.subLinks
             }"
             ng-click="$ctrl.closeMenuWithCallback($event, menuLink.click)"
-            ng-bind-html="::menuLink.title"
+            ng-bind="::menuLink.title"
             ui-sref="{{::$ctrl.constructor.getFullSref(menuLink)}}"
             oui-navbar-group="{{::$ctrl.menuName}}"
             oui-navbar-group-last="::$last">
@@ -79,7 +79,7 @@
             ng-attr-aria-label="{{::!!menuLink.label ? menuLink.label : null}}"
             ng-attr-title="{{::!!menuLink.label ? menuLink.label : null}}"
             ng-click="$ctrl.closeMenuWithCallback($event, menuLink.click)"
-            ng-bind-html="::menuLink.title"
+            ng-bind="::menuLink.title"
             oui-navbar-group="{{::$ctrl.menuName}}"
             oui-navbar-group-last="::$last">
         </button>
@@ -95,7 +95,7 @@
                 'oui-navbar_mobile-only': !!menuLink.url || !!menuLink.state
             }"
             ng-click="$ctrl.navbarCtrl.toggleMenu(menuLink.name, true)"
-            ng-bind-html="::menuLink.title"
+            ng-bind="::menuLink.title"
             oui-navbar-group="{{::$ctrl.menuName}}"
             oui-navbar-group-last="::$last">
         </button>


### PR DESCRIPTION
ref: UK-188
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

## Remove vulnerable `ng-bind-html`
### Description of the Change

Remove `ng-bind-html` which could be exposed to user inputs, in order to avoid HTML injection.