### PR TITLE
Fix/oui chips button type

### DIFF
--- a/packages/components/chips/src/js/chips.html
+++ b/packages/components/chips/src/js/chips.html
@@ -6,6 +6,7 @@
     ng-class="::{ 'oui-chip_block': !!$ctrl.stacked }">
 </span>
 <button class="oui-chip oui-chip_closable"
+    type="button"
     ng-if="::!!$ctrl.closable"
     ng-click="$ctrl.removeItem($index)"
     ng-repeat="item in $ctrl.items"


### PR DESCRIPTION
## Title of the Pull Requests <!-- required -->
Fix: add button type to oui-chips

### Description of the Change

oui-chips component uses a html5 button element when closable property is set to true. This html element as a type property set to "submit" by default, and thus having it in a form would submit it.
Fix set the button type to "button" to avoid this side effect.

### Benefits

Closing a oui-chip in a form will not submit the form anymore.