### PR TITLE
fix(tooltip): fix work-break inheritance

### DIFF
--- a/packages/base/core/src/less/mixins/tooltip.less
+++ b/packages/base/core/src/less/mixins/tooltip.less
@@ -28,6 +28,7 @@
     font-size: @font-size;
     font-weight: @font-weight;
     white-space: normal;
+    word-break: break-word;
     color: @font-color;
     box-shadow: @box-shadow;
     border: solid @border-width @border-color;


### PR DESCRIPTION
## Tooltip - work-break inheritance

### Description of the Change

#### :bug: Bug Fixes

7c48ad1 - fix(tooltip): fix work-break inheritance

### Benefits

Improve the way that content is display inside a popover element.

### Applicable Issues

#774

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>