### PR TITLE
fix(datagrid): dynamic data management for helper

### DIFF
--- a/packages/components/datagrid/src/js/datagrid-column-builder.service.js
+++ b/packages/components/datagrid/src/js/datagrid-column-builder.service.js
@@ -78,6 +78,11 @@ export default class DatagridColumnBuilder {
         column.title = this.buildTitle(column.rawTitle, $scope);
       }
 
+      if (hasAttribute(element, 'helper')) {
+        column.rawHelper = getAttribute(element, 'helper');
+        column.helper = this.$parse(column.rawHelper)($scope);
+      }
+
       // If one column has a footer, we set true for all
       if (column.footer) {
         hasFooter = true;

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -865,7 +865,7 @@ describe('ouiDatagrid', () => {
         const element = TestUtils.compileTemplate(`
                     <oui-datagrid rows="$ctrl.rows"
                         columns="$ctrl.columns">
-                        <oui-datagrid-column property="firstName" type="text" helper="Helper text"></oui-datagrid-column>
+                        <oui-datagrid-column property="firstName" type="text" helper="'Helper text'"></oui-datagrid-column>
                     </oui-datagrid>
                 `, {
           columns: columnsData.columns1,


### PR DESCRIPTION
ref: MANAGER-9195
Signed-off-by: Guillaume Hyenne <guillaume.hyenne@ovhcloud.com>

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Add dynamic data management for helper <!-- required -->


### Description of the Change
I added the dynamic data management for helper.
<!-- required -->
<!-- Can be a listing of commit descriptions -->

### Benefits
Allows to put a content of a variable (for example a translation) and not only a static content.
::myVar | translate or $ctrl.myVar allows you to display the content.
Before change, we the result of the popover would be '$ctrl.myVar' and not the content of the variable.
<!-- optional -->
<!-- What benefits will be achieved by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
