### PR TITLE
feat(oui-tile): add top attribute on oui-tile-button

### DIFF
--- a/packages/components/tile/README.md
+++ b/packages/components/tile/README.md
@@ -22,6 +22,7 @@ angular.module('myModule', ['oui.tile']);
 | `aria-label`      | string    | @?        | no                | n/a               | `null`    | accessibility label
 | `disabled`        | boolean   | <?        | no                | `true`, `false`   | `false`   | disabled flag
 | `external`        | boolean   | <?        | yes               | `true`, `false`   | `false`   | open in new tab and display external icon
+| `top`             | boolean   | <?        | yes               | `true`, `false`   | `false`   | target top flag (incompatible with external flag)
 | `on-click`        | funcion   | &         | no                | n/a               | n/a       | button action callback
 
 ## Component `oui-tile-definition`

--- a/packages/components/tile/src/js/button/tile-button.component.js
+++ b/packages/components/tile/src/js/button/tile-button.component.js
@@ -9,6 +9,7 @@ export default {
     ariaLabel: '@?',
     disabled: '<?',
     external: '<?',
+    top: '<?',
     onClick: '&',
   },
   transclude: true,

--- a/packages/components/tile/src/js/button/tile-button.controller.js
+++ b/packages/components/tile/src/js/button/tile-button.controller.js
@@ -12,6 +12,14 @@ export default class {
   $onInit() {
     addBooleanParameter(this, 'disabled');
     addBooleanParameter(this, 'external');
+    addBooleanParameter(this, 'top');
+
+    if (this.top) {
+      this.linkTarget = '_top';
+    } else if (this.external) {
+      this.linkTarget = '_blank';
+      this.linkRel = 'noopener';
+    }
   }
 
   $postLink() {

--- a/packages/components/tile/src/js/button/tile-button.html
+++ b/packages/components/tile/src/js/button/tile-button.html
@@ -12,8 +12,8 @@
     ng-if="::!!$ctrl.href && !$ctrl.disabled"
     class="oui-tile__button oui-button oui-button_ghost oui-button_icon-right oui-button_block"
     ng-href="{{:: $ctrl.href }}"
-    ng-attr-rel="{{:: $ctrl.external ? 'noopener' : undefined }}"
-    ng-attr-target="{{:: $ctrl.external ? '_blank' : undefined }}"
+    ng-attr-rel="{{::$ctrl.linkRel}}"
+    ng-attr-target="{{::$ctrl.linkTarget}}"
     ng-attr-aria-label="{{ :: $ctrl.ariaLabel }}"
     ng-click="$ctrl.onClick()">
     <span ng-transclude></span>

--- a/packages/components/tile/src/js/tile.spec.js
+++ b/packages/components/tile/src/js/tile.spec.js
@@ -106,6 +106,20 @@ describe('ouiTile', () => {
       expect(button.attr('target')).toBe(targetAttr);
     });
 
+    it('should add a target _top when top is passed', () => {
+      const element = TestUtils.compileTemplate(
+        `<oui-tile>
+            <oui-tile-button href="http://myurl.com" top>text</oui-tile-button>
+        </oui-tile>`,
+      );
+
+      const button = getTileButton(element);
+
+      $timeout.flush();
+
+      expect(button.attr('target')).toBe('_top');
+    });
+
     it('should handle click in a button tile', () => {
       const clickSpy = jasmine.createSpy('click');
       const hrefClickSpy = jasmine.createSpy('click');


### PR DESCRIPTION
Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>

### Description of the Change
Handle the target="_top" of links in the oui-tile-button.

### Benefits
Possibility to add target top to tile button.