### PR TITLE
fix(oui.datagrid): delay offset reset on remote data refresh

### DIFF
--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -273,10 +273,20 @@ export default class DatagridController {
       });
     }
 
+    const delayOffsetReset = typeof this.rowsLoader === 'function';
     this.refreshData(() => {
-      this.paging.setOffset(1);
+      // If rows loader function is defined, we should not change offset before refreshing data
+      if (!delayOffsetReset) {
+        this.paging.setOffset(1);
+      }
       this.paging.setCriteria(criteria);
-    }, false);
+    }, false)
+      .then(() => {
+        // Reset the offset after data refresh
+        if (delayOffsetReset) {
+          this.paging.setOffset(1);
+        }
+      });
   }
 
   onPaginationChange({ offset, pageSize }) {


### PR DESCRIPTION
ref: DTRSD-93312

Signed-off-by: Jérémy DE CESARE <jeremy.de-cesare@ovhcloud.com>

### Description of the Change

Delay offset reset after using it to fetch remote data, allowing search with criteria on paginated results, for those listed in other pages than first one.