### PR TITLE
feat(datagrid): add callback method on expandable row

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
@@ -224,7 +224,7 @@ export const ExpandableRows = forModule(moduleName).createElement(
       <oui-datagrid-column title="'Last name'" property="lastName"></oui-datagrid-column>
       <oui-datagrid-column title="'Email'" property="email"></oui-datagrid-column>
       <oui-datagrid-column title="'Phone'" property="phone"></oui-datagrid-column>
-      <oui-datagrid-row-detail>
+      <oui-datagrid-row-detail on-row-expand="$ctrl.onRowExpand()">
         Birth date : <span ng-bind="$row.birth"></span>
         <br />
         Parents :
@@ -234,6 +234,7 @@ export const ExpandableRows = forModule(moduleName).createElement(
     {
       $ctrl: {
         data,
+        onRowExpand: action('onRowExpand'),
       },
     },
   ),

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -410,6 +410,7 @@ export default class DatagridController {
     if (this.expandableRows) {
       if (!this.isRowExpanded(index)) {
         this.expandedRows.push(index);
+        this.onRowExpand();
       } else {
         this.expandedRows.splice(this.expandedRows.indexOf(index), 1);
       }
@@ -418,6 +419,13 @@ export default class DatagridController {
 
   isRowExpanded(index) {
     return this.expandedRows.includes(index);
+  }
+
+  onRowExpand() {
+    if (angular.isFunction(this.onRowExpand)) {
+      return true;
+    }
+    return null;
   }
 
   static createEmptyRows(pageSize) {

--- a/packages/components/datagrid/src/js/datagrid.html
+++ b/packages/components/datagrid/src/js/datagrid.html
@@ -154,7 +154,7 @@
                 <td class="oui-datagrid-row-detail__cell"
                     ng-repeat="rowDetail in $ctrl.rowDetailElements track by $index"
                     ng-attr-colspan="{{$last ? $ctrl.columns.length - $ctrl.rowDetailElements.length + 1 : 1}}">
-                    <oui-datagrid-row-detail class="oui-datagrid-row-detail__container" row="row" index="$index">
+                    <oui-datagrid-row-detail class="oui-datagrid-row-detail__container" row="row" index="$index" on-row-expand="$ctrl.onRowExpand()">
                     </oui-datagrid-row-detail>
                 </td>
             </tr>

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -534,7 +534,7 @@ describe('ouiDatagrid', () => {
                 <oui-datagrid-column property="firstName"></oui-datagrid-column>
                 <oui-datagrid-column property="lastName"></oui-datagrid-column>
                 <oui-datagrid-column property="description"></oui-datagrid-column>
-                <oui-datagrid-row-detail>
+                <oui-datagrid-row-detail on-row-expand="$ctrl.onRowExpand()">
                     Contact informations :
                     <ul>
                         <li>Email : <span ng-bind="$row.email"></span></li>
@@ -552,6 +552,9 @@ describe('ouiDatagrid', () => {
         ctrl.toggleRowExpansion(0);
         expect(ctrl.expandedRows.length).toEqual(1);
         expect(ctrl.isRowExpanded(0)).toBe(true);
+        spyOn(ctrl, 'onRowExpand').and.callThrough();
+        ctrl.onRowExpand();
+        expect(ctrl.onRowExpand).toHaveBeenCalled();
         expect(element.find('<span ng-bind="$row.phone>')).not.toBe(null);
         expect(ctrl.isRowExpanded(1)).toBe(false);
         expect(ctrl.isRowExpanded(2)).toBe(false);

--- a/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.component.js
+++ b/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.component.js
@@ -8,5 +8,6 @@ export default {
   bindings: {
     row: '<',
     index: '<',
+    onRowExpand: '&?',
   },
 };

--- a/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.controller.js
+++ b/packages/components/datagrid/src/js/row-detail/datagrid-row-detail.controller.js
@@ -8,6 +8,7 @@ export default class {
   $postLink() {
     this.rowDetailScope = this.datagridCtrl.getParentScope().$new(false);
     this.compileElement();
+    this.onRowExpand();
   }
 
   compileElement() {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
  Optional callback method for datagrid expand row


### Description of the Change

<!-- required -->
<!-- Can be a listing of commit descriptions -->
Addition of optional callback method `onRowExpand()` to handle api call or any other functionality on datagrid row expand.

### Benefits

<!-- optional -->
<!-- What benefits will be achieved by the code change? -->
On adding the optional `onRowExpand()` callback method, we can handle some scenario like calling api on row expand. By doing this it can increase performance if we want to display some data which will be returned by some api.
Eg: In private network grid, we need to display `Private network list with its subnet`. We need to display subnet on expand of each row. If we call private network list endpoint and subnet endpoint for each private network , it will be a costly call and will hit the performance badly.

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->
Couldn't  think of anything. As its an optional callback method.
### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
Private network list page.
[MANAGER-9681]