### PR TITLE
feat(datagrid): page-size-max option for datagrid

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
@@ -55,6 +55,7 @@ export const Pagination = forModule(moduleName).createElement(
     `
     <oui-datagrid
       page-size="5"
+      page-size-max="100"
       rows="$ctrl.data"
       on-page-change="$ctrl.onPageChange($pagination)">
       <oui-datagrid-column title="'First name'" property="firstName"></oui-datagrid-column>

--- a/packages/components/datagrid/README.md
+++ b/packages/components/datagrid/README.md
@@ -29,6 +29,7 @@ angular.module('myModule', ['oui.datagrid'])
 | ----                              | ----      | ----      | ----                | ----             | ----         | ----
 | `id`                              | string    | @?        | no                  | n/a              | n/a          | id of the datagrid
 | `page-size`                       | number    | @?        | no                  | n/a              | `25`         | maximum number of rows to show on each pages
+ `page-size-max`                    | number    | @?        | no                  | n/a              | n/a          | max page size of the page sizes list
 | `page`                            | number    | @?        | no                  | n/a               | `1`         | page to display
 | `rows`                            | array     | <?        | yes                 | n/a              | n/a          | local rows to load in the datagrid
 | `criteria`                        | array     | <?        | yes                 | n/a              | n/a          | default filter criteria to apply

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -43,6 +43,7 @@ export default class DatagridController {
     this.hasFooter = false;
     this.firstLoading = true;
     this.pageSize = parseInt(this.pageSize, 10) || this.config.pageSize;
+    this.pageSizeMax = parseInt(this.pageSizeMax, 10) || null;
     this.filterableColumns = [];
     this.criteria = this.criteria || [];
     this.page = parseInt(this.page, 10) || 1;
@@ -84,6 +85,7 @@ export default class DatagridController {
         builtColumns.currentSorting,
         this.offset,
         this.pageSize,
+        this.pageSizeMax,
         this.rowLoader,
         this.rowsLoader,
       );
@@ -98,6 +100,7 @@ export default class DatagridController {
         builtColumns.currentSorting,
         this.offset,
         this.pageSize,
+        this.pageSizeMax,
         this.rowLoader,
         this.rows,
       );

--- a/packages/components/datagrid/src/js/datagrid.directive.js
+++ b/packages/components/datagrid/src/js/datagrid.directive.js
@@ -15,6 +15,7 @@ export default () => {
       customizable: '<?',
       page: '@?',
       pageSize: '@?',
+      pageSizeMax: '@?',
       rows: '<?',
       rowsLoader: '&?',
       rowLoader: '&?',

--- a/packages/components/datagrid/src/js/datagrid.html
+++ b/packages/components/datagrid/src/js/datagrid.html
@@ -202,6 +202,7 @@
         class="oui-datagrid-panel__pagination"
         current-offset="$ctrl.paging.offset"
         page-size="$ctrl.paging.pageSize"
+        page-size-max="$ctrl.paging.pageSizeMax"
         total-items="$ctrl.paging.totalCount"
         on-change="$ctrl.onPaginationChange($event)">
     </oui-pagination>

--- a/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
@@ -2,8 +2,27 @@ import DatagridPagingAbstract from './datagrid-paging-abstract';
 import Filter from '../filter/filter';
 
 export default class DatagridLocalPaging extends DatagridPagingAbstract {
-  constructor(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService, rows) {
-    super(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService);
+  constructor(
+    columns,
+    criteria,
+    currentSorting,
+    offset,
+    pageSize,
+    pageSizeMax,
+    rowLoader,
+    pagingService,
+    rows,
+  ) {
+    super(
+      columns,
+      criteria,
+      currentSorting,
+      offset,
+      pageSize,
+      pageSizeMax,
+      rowLoader,
+      pagingService,
+    );
 
     this.setRows(rows);
   }

--- a/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
@@ -1,9 +1,19 @@
 export default class DatagridPagingAbstract {
-  constructor(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService) {
+  constructor(
+    columns,
+    criteria,
+    currentSorting,
+    offset,
+    pageSize,
+    pageSizeMax,
+    rowLoader,
+    pagingService,
+  ) {
     this.columns = columns;
     this.currentSorting = currentSorting;
     this.criteria = criteria;
     this.pageSize = pageSize;
+    this.pageSizeMax = pageSizeMax;
     this.offset = offset;
     this.rowLoader = rowLoader;
 

--- a/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
@@ -10,26 +10,28 @@ export default class {
     this.orderByFilter = orderByFilter;
   }
 
-  createLocal(columns, criteria, sorting, offset, pageSize, rowLoader, rows) {
+  createLocal(columns, criteria, sorting, offset, pageSize, pageSizeMax, rowLoader, rows) {
     return new DatagridLocalPaging(
       columns,
       criteria,
       sorting,
       offset,
       pageSize,
+      pageSizeMax,
       rowLoader,
       this,
       rows,
     );
   }
 
-  createRemote(columns, criteria, sorting, offset, pageSize, rowLoader, rowsLoader) {
+  createRemote(columns, criteria, sorting, offset, pageSize, pageSizeMax, rowLoader, rowsLoader) {
     return new DatagridRemotePaging(
       columns,
       criteria,
       sorting,
       offset,
       pageSize,
+      pageSizeMax,
       rowLoader,
       this,
       rowsLoader,

--- a/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
@@ -7,11 +7,21 @@ export default class DatagridRemotePaging extends DatagridPagingAbstract {
     currentSorting,
     offset,
     pageSize,
+    pageSizeMax,
     rowLoader,
     pagingService,
     rowsLoader,
   ) {
-    super(columns, criteria, currentSorting, offset, pageSize, rowLoader, pagingService);
+    super(
+      columns,
+      criteria,
+      currentSorting,
+      offset,
+      pageSize,
+      pageSizeMax,
+      rowLoader,
+      pagingService,
+    );
 
     this.rowsLoader = rowsLoader;
   }


### PR DESCRIPTION
### Requirements

* Datagrid by default displays [25, 50, 100, 300] options for the page-size. But the we have a requirement to display a max of 100 as page-size.

## Title of the Pull Requests <!-- required -->

`page-size-max` option for datagrid

### Description of the Change

 Max page size option user can select in datagrid
