### PR TITLE
fix(build): export default library name

### DIFF
--- a/packages/apps/builder/.config/webpack.config.js
+++ b/packages/apps/builder/.config/webpack.config.js
@@ -8,8 +8,8 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 module.exports = merge(baseConfig, {
   entry: {
     'oui': [
-      './src/oui.js',
       './src/oui.less',
+      './src/oui.js',
     ],
     'oui-flags': [
       './src/oui-flags.less',
@@ -22,6 +22,7 @@ module.exports = merge(baseConfig, {
     filename: '[name].js',
     library: 'oui',
     libraryTarget: 'umd',
+    libraryExport: 'default',
     path: path.resolve('.', 'dist', 'js'),
     // libraryTarget: 'umd',
   },


### PR DESCRIPTION
## Fix(build): export default library name

Export is currently empty and has no default member
Export the library's module name a.k.a `oui` as default member

ES6 import before this fix
```javascript
import uiKit from 'ovh-ui-kit' // uiKit === undefined
```
ES6 import after this fix
```javascript
import uiKit from 'ovh-ui-kit' // uiKit === "oui"
```
This can then be used right inside `angular.module` definition
```javascript
import uiKit from 'ovh-ui-kit'
angular.module('myModule', [uiKit])
```


If the exports object is undefined, the library's value is exposed on the global object through the `oui` property
Global UMD import before this fix (for instance, in the browser)
```javascript
window.oui // undefined
```
Global UMD import after this fix (for instance, in the browser)
```javascript
window.oui // "oui"
```
### From webpack documentation
![image](https://user-images.githubusercontent.com/3984480/219133003-2cb7a264-d955-438c-849a-b36c239766f2.png)
![image](https://user-images.githubusercontent.com/3984480/219133254-888badb4-0fbc-412f-90b7-e8bce7bcea30.png)

