### PR TITLE
feat(datagrid): add pagination-mode option

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/datagrid/datagrid-webcomponent.stories.js
@@ -7,6 +7,7 @@ import Datagrid from '@ovh-ux/ui-kit.datagrid';
 
 import { action } from '@storybook/addon-actions';
 import { forModule } from 'storybook-addon-angularjs';
+import { select } from '@storybook/addon-knobs';
 
 import readme from '@ovh-ux/ui-kit.datagrid/README.md';
 import { compileTemplate } from '../../../../src/utils';
@@ -459,4 +460,36 @@ export const RemoteData = forModule(moduleName).createElement(
   ),
 );
 
-RemoteData.storyName = 'Remote data';
+const paginationMode = {
+  label: 'Mode',
+  options: {
+    Button: 'button',
+    Select: 'select',
+    Input: 'input',
+    Arrows: 'arrows',
+  },
+};
+paginationMode.default = paginationMode.options.Arrows;
+
+
+export const PaginationMode = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-datagrid
+      page-size="5"
+      rows="$ctrl.data"
+      pagination-mode="${select(paginationMode.label, paginationMode.options, paginationMode.default)}">
+      <oui-datagrid-column title="'First name'" property="firstName"></oui-datagrid-column>
+      <oui-datagrid-column title="'Last name'" property="lastName"></oui-datagrid-column>
+      <oui-datagrid-column title="'Email'" property="email"></oui-datagrid-column>
+      <oui-datagrid-column title="'Phone'" property="phone"></oui-datagrid-column>
+    </oui-datagrid>`,
+    {
+      $ctrl: {
+        data: data.slice(0, 30),
+      },
+    },
+  ),
+);
+
+PaginationMode.storyName = 'Pagination Mode';

--- a/packages/apps/workshop/stories/design-system/components/pagination/pagination-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/pagination/pagination-webcomponent.stories.js
@@ -17,6 +17,7 @@ const mode = {
     Button: 'button',
     Select: 'select',
     Input: 'input',
+    Arrows: 'arrows',
   },
   default: '',
 };

--- a/packages/components/datagrid/README.md
+++ b/packages/components/datagrid/README.md
@@ -25,20 +25,21 @@ angular.module('myModule', ['oui.datagrid'])
 
 ## Component `oui-datagrid`
 
-| Attribute                         | Type      | Binding   | One-time binding    | Values           | Default      | Description
-| ----                              | ----      | ----      | ----                | ----             | ----         | ----
-| `id`                              | string    | @?        | no                  | n/a              | n/a          | id of the datagrid
-| `page-size`                       | number    | @?        | no                  | n/a              | `25`         | maximum number of rows to show on each pages
- `page-size-max`                    | number    | @?        | no                  | n/a              | n/a          | max page size of the page sizes list
-| `page`                            | number    | @?        | no                  | n/a               | `1`         | page to display
-| `rows`                            | array     | <?        | yes                 | n/a              | n/a          | local rows to load in the datagrid
-| `criteria`                        | array     | <?        | yes                 | n/a              | n/a          | default filter criteria to apply
-| `empty-placeholder`               | string    | @?        | yes                 | n/a              | n/a          | custom placeholder text when there is no data
-| `selectable-rows`                 | boolean   | <?        | no                  | `true`, `false`  | `false`      | allow rows to be selected. Create a sticky column a the start of the datagrid.
-| `on-criteria-change`              | function  | &         | no                  | n/a              | n/a          | triggered when criteria changed. Use `$criteria` in your callback to get the result
-| `on-page-change`                  | function  | &         | no                  | n/a              | n/a          | triggered when pagination is changed
-| `on-row-select`                   | function  | &         | no                  | n/a              | n/a          | triggered when a row is selected
-| `on-sort-change`                  | function  | &         | no                  | n/a              | n/a          | triggered when sort is triggered. Use `$sort` in your callback to get the result
+| Attribute                         | Type      | Binding   | One-time binding    | Values                                 | Default      | Description
+| ----                              | ----      | ----      | ----                | ----                                   | ----         | ----
+| `id`                              | string    | @?        | no                  | n/a                                    | n/a          | id of the datagrid
+| `page-size`                       | number    | @?        | no                  | n/a                                    | `25`         | maximum number of rows to show on each pages
+ `page-size-max`                    | number    | @?        | no                  | n/a                                    | n/a          | max page size of the page sizes list
+| `page`                            | number    | @?        | no                  | n/a                                    | `1`          | page to display
+| `rows`                            | array     | <?        | yes                 | n/a                                    | n/a          | local rows to load in the datagrid
+| `criteria`                        | array     | <?        | yes                 | n/a                                    | n/a          | default filter criteria to apply
+| `empty-placeholder`               | string    | @?        | yes                 | n/a                                    | n/a          | custom placeholder text when there is no data
+| `selectable-rows`                 | boolean   | <?        | no                  | `true`, `false`                        | `false`      | allow rows to be selected. Create a sticky column a the start of the datagrid.
+| `on-criteria-change`              | function  | &         | no                  | n/a                                    | n/a          | triggered when criteria changed. Use `$criteria` in your callback to get the result
+| `on-page-change`                  | function  | &         | no                  | n/a                                    | n/a          | triggered when pagination is changed
+| `on-row-select`                   | function  | &         | no                  | n/a                                    | n/a          | triggered when a row is selected
+| `on-sort-change`                  | function  | &         | no                  | n/a                                    | n/a          | triggered when sort is triggered. Use `$sort` in your callback to get the result
+| `pagination-mode`                 | string    | @?        | no                  | `button`, `select`, `input`, `arrows`  | `input`      | Set the pagination mode
 
 ### Custom cell templates
 

--- a/packages/components/datagrid/src/index.js
+++ b/packages/components/datagrid/src/index.js
@@ -37,4 +37,5 @@ angular
   .service('ouiDatagridService', DatagridService)
   .component('ouiDatagridParameters', DatagridParameters);
 
+export { PAGINATION_MODES } from './js/datagrid.controller';
 export default moduleName;

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -1,4 +1,5 @@
 import { addBooleanParameter, addDefaultParameter } from '@ovh-ux/ui-kit.core/src/js/component-utils';
+import { MODES as PAGINATION_MODES } from '@ovh-ux/ui-kit.pagination';
 import find from 'lodash/find';
 import hasIn from 'lodash/hasIn';
 
@@ -10,6 +11,8 @@ const cssSortable = 'oui-datagrid__header_sortable';
 const iconSortable = 'oui-icon-sort-inactive';
 const iconSortableAsc = 'oui-icon-sort-up';
 const iconSortableDesc = 'oui-icon-sort-down';
+
+export { PAGINATION_MODES };
 
 export default class DatagridController {
   constructor($attrs, $compile, $element, $transclude, $q, $scope, $window, $timeout,
@@ -48,6 +51,7 @@ export default class DatagridController {
     this.criteria = this.criteria || [];
     this.page = parseInt(this.page, 10) || 1;
     this.offset = (this.page - 1) * this.pageSize + 1;
+    this.paginationMode = (PAGINATION_MODES.includes(this.paginationMode) && this.paginationMode) || '';
 
     addBooleanParameter(this, 'selectableRows');
     addDefaultParameter(this, 'emptyPlaceholder', this.config.translations.emptyPlaceholder);
@@ -88,6 +92,7 @@ export default class DatagridController {
         this.pageSizeMax,
         this.rowLoader,
         this.rowsLoader,
+        this.paginationMode,
       );
       this.refreshData(() => {
         this.paging.setOffset(this.offset);
@@ -103,6 +108,7 @@ export default class DatagridController {
         this.pageSizeMax,
         this.rowLoader,
         this.rows,
+        this.paginationMode,
       );
 
       if (this.rows) {
@@ -124,6 +130,17 @@ export default class DatagridController {
 
     if (changes.columnsParameters && !changes.columnsParameters.isFirstChange()) {
       this.buildColumns();
+    }
+
+    if (changes.paginationMode && !changes.paginationMode.isFirstChange()) {
+      const { currentValue: paginationMode } = changes.paginationMode;
+
+      if (!PAGINATION_MODES.includes(paginationMode)) {
+        return;
+      }
+
+      this.paginationMode = paginationMode;
+      this.paging.paginationMode = paginationMode;
     }
   }
 

--- a/packages/components/datagrid/src/js/datagrid.directive.js
+++ b/packages/components/datagrid/src/js/datagrid.directive.js
@@ -25,6 +25,7 @@ export default () => {
       onPageChange: '&',
       onRowSelect: '&',
       onSortChange: '&',
+      paginationMode: '@?',
     },
     compile: (elm) => {
       // Transclude can't be used here otherwise transcluded

--- a/packages/components/datagrid/src/js/datagrid.html
+++ b/packages/components/datagrid/src/js/datagrid.html
@@ -204,6 +204,7 @@
         page-size="$ctrl.paging.pageSize"
         page-size-max="$ctrl.paging.pageSizeMax"
         total-items="$ctrl.paging.totalCount"
-        on-change="$ctrl.onPaginationChange($event)">
+        on-change="$ctrl.onPaginationChange($event)"
+        mode="{{ $ctrl.paging.paginationMode }}">
     </oui-pagination>
 </div>

--- a/packages/components/datagrid/src/js/datagrid.spec.js
+++ b/packages/components/datagrid/src/js/datagrid.spec.js
@@ -1,7 +1,11 @@
+import { last } from 'lodash';
+
 import '@ovh-ux/ui-kit.action-menu';
 
+import { PAGINATION_MODES } from './datagrid.controller';
 import columnsData from './columns.spec.data.json';
 import originalFakeData from './datagrid.spec.data.json';
+
 
 describe('ouiDatagrid', () => {
   let TestUtils;
@@ -18,6 +22,7 @@ describe('ouiDatagrid', () => {
   const getFooterCell = (element, columnNumber) => angular.element(element[0].querySelectorAll('.oui-datagrid__footer')[columnNumber]);
   const getCell = (element, columnNumber) => angular.element(element[0].querySelectorAll('.oui-datagrid__cell')[columnNumber]);
   const getNextPagePaginationButton = (element) => angular.element(element[0].querySelector('.oui-pagination-nav__next'));
+  const getPaginationNav = (element) => angular.element(element[0].querySelector('.oui-pagination-nav'));
   const isSortableCell = (element) => element.hasClass('oui-datagrid__header_sortable');
   const isSortableAscCell = (element) => {
     const isSortable = isSortableCell(element);
@@ -1393,6 +1398,33 @@ describe('ouiDatagrid', () => {
       getNextPagePaginationButton(element).triggerHandler('click');
 
       expect(onPageChangeSpy).toHaveBeenCalled();
+    });
+
+    it('should pass through the pagination mode', () => {
+      const element = TestUtils.compileTemplate(`
+            <oui-datagrid rows="$ctrl.rows" page-size="2" pagination-mode="{{ $ctrl.paginationMode }}">
+                <oui-column property="firstName"></oui-column>
+            </oui-datagrid>
+        `, {
+        rows: fakeData.slice(0, 5),
+      });
+
+      const setMode = (mode) => {
+        TestUtils.getElementController(element).paginationMode = mode;
+        element.scope().$apply();
+      };
+      const controller = element.controller('ouiDatagrid');
+      const paginationController = getPaginationNav(element).controller('ouiPagination');
+
+      PAGINATION_MODES.forEach((paginationMode) => {
+        setMode(paginationMode);
+        expect(controller.paging.paginationMode).toBe(paginationMode);
+        expect(paginationController.mode).toBe(paginationMode);
+      });
+
+      setMode('unknown');
+      expect(controller.paging.paginationMode).toBe(last(PAGINATION_MODES));
+      expect(paginationController.mode).toBe(last(PAGINATION_MODES));
     });
 
     it('should support action-menu as column', () => {

--- a/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-local-paging.js
@@ -12,6 +12,7 @@ export default class DatagridLocalPaging extends DatagridPagingAbstract {
     rowLoader,
     pagingService,
     rows,
+    paginationMode,
   ) {
     super(
       columns,
@@ -22,6 +23,7 @@ export default class DatagridLocalPaging extends DatagridPagingAbstract {
       pageSizeMax,
       rowLoader,
       pagingService,
+      paginationMode,
     );
 
     this.setRows(rows);

--- a/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging-abstract.js
@@ -8,6 +8,7 @@ export default class DatagridPagingAbstract {
     pageSizeMax,
     rowLoader,
     pagingService,
+    paginationMode,
   ) {
     this.columns = columns;
     this.currentSorting = currentSorting;
@@ -16,6 +17,7 @@ export default class DatagridPagingAbstract {
     this.pageSizeMax = pageSizeMax;
     this.offset = offset;
     this.rowLoader = rowLoader;
+    this.paginationMode = paginationMode;
 
     this.$q = pagingService.$q;
     this.$timeout = pagingService.$timeout;

--- a/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-paging.service.js
@@ -10,7 +10,17 @@ export default class {
     this.orderByFilter = orderByFilter;
   }
 
-  createLocal(columns, criteria, sorting, offset, pageSize, pageSizeMax, rowLoader, rows) {
+  createLocal(
+    columns,
+    criteria,
+    sorting,
+    offset,
+    pageSize,
+    pageSizeMax,
+    rowLoader,
+    rows,
+    paginationMode,
+  ) {
     return new DatagridLocalPaging(
       columns,
       criteria,
@@ -21,10 +31,21 @@ export default class {
       rowLoader,
       this,
       rows,
+      paginationMode,
     );
   }
 
-  createRemote(columns, criteria, sorting, offset, pageSize, pageSizeMax, rowLoader, rowsLoader) {
+  createRemote(
+    columns,
+    criteria,
+    sorting,
+    offset,
+    pageSize,
+    pageSizeMax,
+    rowLoader,
+    rowsLoader,
+    paginationMode,
+  ) {
     return new DatagridRemotePaging(
       columns,
       criteria,
@@ -35,6 +56,7 @@ export default class {
       rowLoader,
       this,
       rowsLoader,
+      paginationMode,
     );
   }
 }

--- a/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
+++ b/packages/components/datagrid/src/js/paging/datagrid-remote-paging.js
@@ -11,6 +11,7 @@ export default class DatagridRemotePaging extends DatagridPagingAbstract {
     rowLoader,
     pagingService,
     rowsLoader,
+    paginationMode,
   ) {
     super(
       columns,
@@ -21,6 +22,7 @@ export default class DatagridRemotePaging extends DatagridPagingAbstract {
       pageSizeMax,
       rowLoader,
       pagingService,
+      paginationMode,
     );
 
     this.rowsLoader = rowsLoader;
@@ -42,6 +44,10 @@ export default class DatagridRemotePaging extends DatagridPagingAbstract {
   loadRows(pageResult) {
     this.loadRowsData(pageResult.data);
     this.totalCount = pageResult.meta.totalCount;
+
+    if (pageResult.meta.currentOffset) {
+      this.offset = pageResult.meta.currentOffset;
+    }
 
     return pageResult;
   }

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -34,6 +34,7 @@ angular.module('myModule', ['oui.pagination'])
 
 | Attribute         | Type      | Binding   | One-time Binding  | Values    | Default   | Description
 | ----              | ----      | ----      | ----              | ----      | ----      | ----
+| `mode`            | string    | @?        | no                | n/a       | n/a       | Set the pagination mode. It can be one these values : `button`, `select`, `input` or `arrows` 
 | `current-offset`  | number    | <         | no                | n/a       | n/a       | offset of the current page first item
 | `page-size`       | number    | <?        | no                | n/a       | `25`      | number of items per page
 | `page-size-max`   | number    | <?        | no                | n/a       | n/a       | max page size of the page sizes list

--- a/packages/components/pagination/src/index.js
+++ b/packages/components/pagination/src/index.js
@@ -3,6 +3,7 @@ import Dropdown from '@ovh-ux/ui-kit.dropdown';
 import Pagination from './js/pagination.component';
 import PaginationConfigurationProvider from './js/pagination.provider';
 
+
 const moduleName = 'oui.pagination';
 
 angular
@@ -12,4 +13,5 @@ angular
   .component('ouiPagination', Pagination)
   .provider('ouiPaginationConfiguration', PaginationConfigurationProvider);
 
+export { MODES } from './js/pagination.controller';
 export default moduleName;

--- a/packages/components/pagination/src/js/pagination.controller.js
+++ b/packages/components/pagination/src/js/pagination.controller.js
@@ -2,10 +2,11 @@ import { addDefaultParameter } from '@ovh-ux/ui-kit.core/src/js/component-utils'
 import clamp from 'lodash/clamp';
 import range from 'lodash/range';
 
-const MODES = [
+export const MODES = [
   'button',
   'select',
   'input',
+  'arrows',
 ];
 
 const MAX_THRESHOLD_MODE = {
@@ -21,6 +22,10 @@ export default class {
     this.$element = $element;
     this.$timeout = $timeout;
     this.config = ouiPaginationConfiguration;
+  }
+
+  get isArrowsMode() {
+    return this.mode === 'arrows';
   }
 
   getCurrentPage() {

--- a/packages/components/pagination/src/js/pagination.html
+++ b/packages/components/pagination/src/js/pagination.html
@@ -1,4 +1,5 @@
-<div class="oui-pagination-result">
+<div class="oui-pagination-result"
+    ng-if="!$ctrl.isArrowsMode">
     <label class="oui-select oui-select_inline">
         <select class="oui-pagination-result__selector oui-select__input"
             ng-change="$ctrl.onPageSizeChange($ctrl.currentPageSize)"
@@ -60,6 +61,7 @@
 
     <!-- Input -->
     <form class="oui-pagination-items oui-pagination-items_input"
+        ng-if="!$ctrl.isArrowsMode"
         ng-switch-default
         novalidate>
         <span aria-hidden="true"

--- a/packages/components/pagination/src/js/pagination.spec.js
+++ b/packages/components/pagination/src/js/pagination.spec.js
@@ -283,6 +283,21 @@ describe('ouiPagination', () => {
         expect(items.hasClass('oui-pagination-items_input')).toBe(true);
       });
 
+      it('should display items in arrows mode', () => {
+        const element = TestUtils.compileTemplate(`
+          <oui-pagination
+            mode="arrows"
+            current-offset="1"
+            total-items="100">
+          </oui-pagination>
+        `);
+
+        expect(getPaginationNavPrevious(element)).toBeDefined();
+        expect(getPaginationNavNext(element)).toBeDefined();
+        expect(getPaginationResult(element)).toBeFalsy();
+        expect(getPaginationItems(element)).toBeFalsy();
+      });
+
       it('should change the mode automatically based on the pageCount', () => {
         let items;
         const element = TestUtils.compileTemplate(`


### PR DESCRIPTION
## feat(datagrid): add pagination-mode option

### Description of the Change

- Add a new `arrows` value to the pagination's `mode` property
- Add the missing documentation for the pagination's `mode` property
- Add a new `pagination-mode` property to the datagrid
- Fix a bug where the `currentOffset` property in the datagrid `rows-loader` return value is not properly handled
