### PR TITLE
fix(dropdown): update popper modifiers option

### DIFF
--- a/packages/components/dropdown/src/js/dropdown.controller.js
+++ b/packages/components/dropdown/src/js/dropdown.controller.js
@@ -158,7 +158,7 @@ export default class {
         },
         preventOverflow: {
           boundariesElement: 'viewport',
-          escapeWithReference: true,
+          escapeWithReference: false,
         },
       },
     });


### PR DESCRIPTION
### Description of the Change

#### Dropdown

Changed Popper modifiers options to disable **escapeWithReference** to avoid dropdown overflowing its boundaries.

See Popper description: 
"When escapeWithReference is set to true and reference is completely outside its boundaries, the popper will overflow (or completely leave) the boundaries in order to remain attached to the edge of the reference."