### PR TITLE
fix(calendar): fix calendar disabled in inline mode

### DIFF
--- a/packages/components/calendar/src/js/calendar.controller.js
+++ b/packages/components/calendar/src/js/calendar.controller.js
@@ -1,4 +1,7 @@
-import { addBooleanParameter, addDefaultParameter } from '@ovh-ux/ui-kit.core/src/js/component-utils';
+import {
+  addBooleanParameter,
+  addDefaultParameter,
+} from '@ovh-ux/ui-kit.core/src/js/component-utils';
 import flatpickr from 'flatpickr/dist/flatpickr';
 import merge from 'lodash/merge';
 
@@ -63,16 +66,14 @@ export default class {
 
     // Append calendar to control wrapper
     if (!this.appendToBody) {
-      const wrapper = this.$element[0].querySelector('.oui-calendar__control-wrapper');
+      const wrapper = this.$element[0].querySelector(
+        '.oui-calendar__control-wrapper',
+      );
       this.setOptionsProperty('appendTo', wrapper);
     }
 
     // Set events with array of supported hooks/attributes
-    this.setEventHooks([
-      'onChange',
-      'onOpen',
-      'onClose',
-    ]);
+    this.setEventHooks(['onChange', 'onOpen', 'onClose']);
 
     // Get instance of flatpickr when component is ready
     this.setOptionsProperty('onReady', (selectedDates, dateStr, instance) => {
@@ -102,14 +103,37 @@ export default class {
     this.initCalendarInstance();
   }
 
+  handleReadonlyElement(htmlElt, hidden = false) {
+    const element = angular.element(htmlElt);
+    if (this.disabled) {
+      element.attr('disabled', 'disabled');
+      element.addClass('disabled');
+      if (hidden) {
+        element.attr('hidden', 'hidden');
+      }
+    } else {
+      element.removeAttr('disabled');
+      element.removeClass('disabled');
+      if (hidden) {
+        element.removeAttr('hidden');
+      }
+    }
+  }
+
   $onChanges({ minDate, maxDate }) {
     if (this.flatpickr) {
       if (this.flatpickr.altInput) {
         // Fix disabled state when there is an alt input
-        if (this.disabled) {
-          angular.element(this.flatpickr.altInput).attr('disabled', 'disabled');
-        } else {
-          angular.element(this.flatpickr.altInput).removeAttr('disabled');
+        this.handleReadonlyElement(this.flatpickr.altInput);
+        // In inline mode, inputs are managed in calendar container
+        if (this.inline) {
+          const { calendarContainer } = this.flatpickr;
+          const inputs = calendarContainer.querySelectorAll('input');
+          angular.forEach(inputs, (input) => {
+            this.handleReadonlyElement(input);
+          });
+          // span AM-PM must be hide to avoid modifiying AM/PM value in readonly mode
+          this.handleReadonlyElement(calendarContainer.querySelectorAll('.flatpickr-am-pm'), true);
         }
       }
 
@@ -129,7 +153,9 @@ export default class {
 
   $postLink() {
     this.$timeout(() => {
-      const controls = angular.element(this.$element[0].querySelectorAll('.oui-calendar__control'));
+      const controls = angular.element(
+        this.$element[0].querySelectorAll('.oui-calendar__control'),
+      );
 
       this.$element
         .addClass('oui-calendar')

--- a/packages/components/calendar/src/js/calendar.spec.js
+++ b/packages/components/calendar/src/js/calendar.spec.js
@@ -164,5 +164,57 @@ describe('ouiCalendar', () => {
       ctrl.flatpickr.close();
       expect(onCloseSpy).toHaveBeenCalledWith([today], ctrl.model);
     });
+
+    it('should disable component in "default" mode', () => {
+      // setup
+      const template = '<oui-calendar model="$ctrl.model" disabled="true"></oui-calendar>';
+
+      // when
+      const component = testUtils.compileTemplate(template);
+
+      // expect
+      const ctrl = component.controller('ouiCalendar');
+      const input = component[0].querySelector('.oui-calendar__control');
+
+      expect(ctrl.disabled).toBeTrue();
+      expect(angular.element(input).attr('disabled')).toBe('disabled');
+    });
+
+    it('should enable and disable component in "inline" mode', () => {
+      // setup: calendar inline
+      const template = `<oui-calendar model="$ctrl.model" disabled="$ctrl.disabled"
+       format="d-m-Y" alt-format="H:i" enable-time inline></oui-calendar>`;
+
+      // when: component is enabled
+      const component = testUtils.compileTemplate(template, { model: 'today', disabled: false });
+      const ctrl = component.controller('ouiCalendar');
+      $timeout.flush();
+
+      // then: none of input are disabled
+      const input = angular.element(component[0].querySelector('.oui-calendar__control'));
+      const altInput = angular.element(component[0].querySelector('.oui-calendar__control_alt'));
+      const inputs = component[0].querySelectorAll('.numInput');
+
+      expect(ctrl.inline).toBeTrue();
+      expect(ctrl.disabled).toBeFalse();
+      expect(angular.element(input).attr('type')).toBe('hidden');
+      expect(angular.element(altInput).attr('type')).toBe('hidden');
+      expect(angular.element(altInput).attr('disabled')).toBeUndefined();
+      angular.forEach(inputs, (i) => {
+        expect(angular.element(i).attr('disabled')).toBeUndefined();
+      });
+
+      // when: component is disabled
+      const scope = component.scope();
+      scope.$ctrl.disabled = true;
+      scope.$apply();
+
+      // then: all inputs are disabled
+      expect(ctrl.disabled).toBeTrue();
+      expect(angular.element(altInput).attr('disabled')).toBe('disabled');
+      angular.forEach(inputs, (i) => {
+        expect(angular.element(i).attr('disabled')).toBe('disabled');
+      });
+    });
   });
 });

--- a/packages/components/calendar/src/less/flatpickr.less
+++ b/packages/components/calendar/src/less/flatpickr.less
@@ -62,6 +62,15 @@
 
         &:hover,
         &:focus { background-color: @oui-calendar-input-background-color_hover; }
+
+        // Disabled
+        &.disabled,
+        &.disabled:hover,
+        &.disabled:focus {
+          font-weight: @oui-calendar-cell-font-weight;
+          color: @oui-calendar-cell-font-color;
+          background: transparent;
+        }
       }
 
       .arrowUp,


### PR DESCRIPTION
ref: DTRSD-115207

github: https://github.com/ovh/ovh-ui-kit/issues/785

## Title of the Pull Requests <!-- required -->
Fix calendar/timepicker disabled in inline mode

### Description of the Change

fix calendar disabled in inline mode. That feature it's not managed by flatpickr

### Benefits

Use of timepicker inline in readonly mode

