### PR TITLE
fix(datagrid): fix cross display in helper tooltip

### DIFF
--- a/packages/components/datagrid/src/less/_mixins.less
+++ b/packages/components/datagrid/src/less/_mixins.less
@@ -76,7 +76,6 @@
           margin-left: @oui-datagrid-arrow-spacing;
           font-size: @oui-datagrid-arrow-size;
           vertical-align: bottom;
-          position: relative;
         }
       }
 


### PR DESCRIPTION
### Description of the Change

#### Datagrid

Removed the position: relative on oui-icon inside the sortable / sorted header, to correctly display the cross icon inside the helper popover
