### PR TITLE
fix(datagrid): fix multiple popover not hiding

### DIFF
--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -360,8 +360,13 @@ export default class DatagridController {
     return this.refreshDatagridPromise;
   }
 
-  sort(column) {
-    if (!column || !column.sortable) {
+  sort(column, event) {
+    if (
+      !column
+      || !column.sortable
+      || event.target.classList.contains('oui-popover-button')
+      || event.target.classList.contains('oui-popover__content')
+      || event.target.classList.contains('oui-popover__close-button')) {
       return;
     }
 

--- a/packages/components/datagrid/src/js/datagrid.controller.js
+++ b/packages/components/datagrid/src/js/datagrid.controller.js
@@ -361,12 +361,11 @@ export default class DatagridController {
   }
 
   sort(column, event) {
+    const popoverClassNames = ['oui-popover-button', 'oui-popover__content', 'oui-popover__close-button'];
     if (
       !column
       || !column.sortable
-      || event.target.classList.contains('oui-popover-button')
-      || event.target.classList.contains('oui-popover__content')
-      || event.target.classList.contains('oui-popover__close-button')) {
+      || popoverClassNames.some((className) => event.target.classList.contains(className))) {
       return;
     }
 

--- a/packages/components/datagrid/src/js/datagrid.html
+++ b/packages/components/datagrid/src/js/datagrid.html
@@ -28,7 +28,7 @@
                     ng-attr-tabindex="{{column.sortable ? '0' : '-1'}}"
                     ng-class="$ctrl.getSortableClasses(column)"
                     ng-repeat="column in $ctrl.columns track by $index"
-                    ng-click="::$ctrl.sort(column)">
+                    ng-click="::$ctrl.sort(column, $event)">
                     <span ng-bind="column.title"></span>
                     <span class="oui-icon"
                         ng-class="$ctrl.getSortableIcons(column)"
@@ -41,6 +41,7 @@
                         class="oui-popover-button"
                         oui-popover="{{:: column.helper }}"
                         oui-popover-placement="right"
+                        oui-popover-id="{{:: 'popover-' + column.name}}"
                     ></button>
                 </th>
                 <th ng-if="$ctrl.hasActionMenu || $ctrl.customizable"

--- a/packages/components/popover/src/js/popover.controller.js
+++ b/packages/components/popover/src/js/popover.controller.js
@@ -119,8 +119,8 @@ export default class PopoverController {
 
     // Avoid events if the opening is handled from outside
     if (angular.isUndefined(this.$attrs.ouiPopoverOpen)) {
-      this.$document.on('click', (evt) => this.documentClickHandler(evt));
-      this.$document.on('keydown', (evt) => this.triggerKeyHandler(evt));
+      this.$document.on(`click.${this.id}`, (evt) => this.documentClickHandler(evt));
+      this.$document.on(`keydown.${this.id}`, (evt) => this.triggerKeyHandler(evt));
     }
 
     this.$element.attr('aria-expanded', true);
@@ -133,8 +133,8 @@ export default class PopoverController {
     this.isPopoverOpen = false;
 
     if (angular.isUndefined(this.$attrs.ouiPopoverOpen)) {
-      this.$document.off('click');
-      this.$document.off('keydown');
+      this.$document.off(`click.${this.id}`);
+      this.$document.off(`keydown.${this.id}`);
     }
 
     this.$element.attr('aria-expanded', false);

--- a/packages/components/popover/src/less/popover.less
+++ b/packages/components/popover/src/less/popover.less
@@ -36,7 +36,7 @@
     min-height: @oui-popover-close-button-icon-size;
     min-width: @oui-popover-close-button-icon-size;
     padding: 0;
-    position: absolute;
+    position: absolute !important;
     right: @oui-popover-close-button-right;
     top: @oui-popover-close-button-top;
 


### PR DESCRIPTION
ref: MANAGER-12609

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Fix popover staying displayed on multiple datagrid helper


### Description of the Change

- Add popover event handlers namespaces based on popover id to fix the multiple popover displayed at the same time issue
- Use datagrid column name as an id for popover helper
- Fix issue when clicking on helper icon or helper popover make the column sort
- Fix popover cross icon position

### Benefits

<!-- optional -->
<!-- What benefits will be achieved by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
