### PR TITLE
feat(form-actions): switch  buttons positions

### DIFF
--- a/packages/components/form-actions/src/js/form-actions.html
+++ b/packages/components/form-actions/src/js/form-actions.html
@@ -1,10 +1,4 @@
 <div class="oui-button-group">
-    <button class="oui-button oui-button_l oui-button_primary"
-        type="submit"
-        ng-bind="::$ctrl.submitText"
-        ng-click="$ctrl.onSubmit()"
-        ng-disabled="$ctrl.disabled">
-    </button>
     <button class="oui-button oui-button_l oui-button_secondary"
         type="button"
         ng-if="::!$ctrl.href && !!$ctrl.onCancel"
@@ -17,4 +11,10 @@
         ng-click="$ctrl.onCancel()"
         ng-href="{{:: $ctrl.href }}">
     </a>
+    <button class="oui-button oui-button_l oui-button_primary"
+        type="submit"
+        ng-bind="::$ctrl.submitText"
+        ng-click="$ctrl.onSubmit()"
+        ng-disabled="$ctrl.disabled">
+    </button>
 </div>

--- a/packages/components/form-actions/src/js/form-actions.spec.js
+++ b/packages/components/form-actions/src/js/form-actions.spec.js
@@ -40,8 +40,8 @@ describe('ouiFormActions', () => {
                     on-submit="$ctrl.submit()"
                     on-cancel="$ctrl.cancel()">
                 </oui-form-actions>`);
-      const submitButton = component.find('button').eq(0);
-      const cancelButton = component.find('button').eq(1);
+      const cancelButton = component.find('button').eq(0);
+      const submitButton = component.find('button').eq(1);
 
       expect(submitButton.hasClass('oui-button_primary')).toBe(true);
       expect(cancelButton.hasClass('oui-button_secondary')).toBe(true);
@@ -53,8 +53,8 @@ describe('ouiFormActions', () => {
                     on-submit="$ctrl.submit()"
                     on-cancel="$ctrl.cancel()">
                 </oui-form-actions>`);
-      const submitButton = component.find('button').eq(0);
-      const cancelButton = component.find('button').eq(1);
+      const cancelButton = component.find('button').eq(0);
+      const submitButton = component.find('button').eq(1);
 
       expect(submitButton.text().trim()).toBe(SUBMIT_TEXT);
       expect(cancelButton.text().trim()).toBe(CANCEL_TEXT);
@@ -68,8 +68,8 @@ describe('ouiFormActions', () => {
                     submit-text="testSubmit"
                     cancel-text="testCancel">
                 </oui-form-actions>`);
-      const submitButton = component.find('button').eq(0);
-      const cancelButton = component.find('button').eq(1);
+      const cancelButton = component.find('button').eq(0);
+      const submitButton = component.find('button').eq(1);
 
       expect(submitButton.text().trim()).toBe('testSubmit');
       expect(cancelButton.text().trim()).toBe('testCancel');
@@ -82,7 +82,7 @@ describe('ouiFormActions', () => {
               on-cancel="$ctrl.cancel()"
               disabled>
           </oui-form-actions>`);
-      const submitButton = component.find('button').eq(0);
+      const submitButton = component.find('button').eq(1);
 
       expect(submitButton.attr('disabled')).toBe('disabled');
     });
@@ -93,7 +93,7 @@ describe('ouiFormActions', () => {
                     on-submit="$ctrl.submit()"
                     on-cancel="$ctrl.cancel()">
                 </oui-form-actions>`);
-      const cancelButton = component.find('button').eq(1);
+      const cancelButton = component.find('button').eq(0);
 
       expect(cancelButton.hasClass('ng-hide')).toBe(false);
     });
@@ -115,7 +115,7 @@ describe('ouiFormActions', () => {
                 </oui-form-actions>`, {
         onSubmitTest: jasmine.createSpy('onSubmit'),
       });
-      component.find('button').eq(0).triggerHandler('click');
+      component.find('button').eq(1).triggerHandler('click');
 
       expect(component.scope().$ctrl.onSubmitTest).toHaveBeenCalled();
     });
@@ -128,7 +128,7 @@ describe('ouiFormActions', () => {
                 </oui-form-actions>`, {
         onCancelTest: jasmine.createSpy('onCancel'),
       });
-      component.find('button').eq(1).triggerHandler('click');
+      component.find('button').eq(0).triggerHandler('click');
 
       expect(component.scope().$ctrl.onCancelTest).toHaveBeenCalled();
     });


### PR DESCRIPTION
ref: MANAGER-12813

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Switch form actions button position


### Description of the Change

The secondary button should be display before the primary button

### Benefits

<!-- optional -->
<!-- What benefits will be achieved by the code change? -->

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
