### PR TITLE
feat(select): adding capacity to use value as item syntax

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/select/select-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/select/select-webcomponent.stories.js
@@ -295,3 +295,24 @@ export const Load = forModule(moduleName).createElement(
     },
   ),
 );
+
+export const PropertyValue = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+      <oui-select
+        items="$ctrl.items"
+        model="$ctrl.model"
+        match="name"
+        value-property="code"
+        name="country"
+      ></oui-select>
+      <span>model value = {{ $ctrl.model }}</span>
+    `,
+    {
+      $ctrl: {
+        model: 'FR',
+        items: countries.map(({ country }) => country),
+      },
+    },
+  ),
+);

--- a/packages/components/select/src/js/select.controller.js
+++ b/packages/components/select/src/js/select.controller.js
@@ -160,6 +160,10 @@ export default class {
     }
   }
 
+  getValue(item) {
+    return get(item, this.valueProperty, item);
+  }
+
   getPropertyValue(item) {
     return get(item, this.match, item);
   }

--- a/packages/components/select/src/js/select.directive.js
+++ b/packages/components/select/src/js/select.directive.js
@@ -18,6 +18,7 @@ export default () => ({
     load: '@?',
     loadOptions: '<?',
     match: '@?',
+    valueProperty: '@?',
     model: '=',
     multiple: '<?',
     name: '@?',

--- a/packages/components/select/src/js/select.html
+++ b/packages/components/select/src/js/select.html
@@ -13,8 +13,8 @@
     <ui-select-match placeholder="{{$ctrl.placeholder}}">
         <span ng-bind-html="$ctrl.getPropertyValue($item)"></span>
     </ui-select-match>
-    <ui-select-choices repeat="$item in $ctrl.items | filter: $select.search track by $index"
-        ui-disable-choice="$ctrl.disableItems({ $item: $item })">
+    <ui-select-choices repeat="$ctrl.getValue($item) as $item in $ctrl.items | filter: $select.search track by $index"
+                       ui-disable-choice="$ctrl.disableItems({ $item: $item })">
         <span ng-bind-html="$ctrl.getPropertyValue($item) | highlight: $select.search"></span>
     </ui-select-choices>
 </ui-select>

--- a/packages/components/select/src/js/select.spec.js
+++ b/packages/components/select/src/js/select.spec.js
@@ -500,6 +500,43 @@ describe('ouiSelect', () => {
       });
     });
 
+    describe('value-property attribute', () => {
+      it('should select the value-property of the selected item', () => {
+        const title = 'Select a country';
+        const placeholder = 'Select a country...';
+        const onChange = jasmine.createSpy();
+        const index = 4;
+
+        const element = TestUtils.compileTemplate(`
+          <oui-select name="country"
+              model="$ctrl.country"
+              title="${title}"
+              placeholder="${placeholder}"
+              items="$ctrl.countries"
+              match="name"
+              value-property="code"
+              on-change="$ctrl.onChange(modelValue)">
+          </oui-select>`, {
+          model: 'FR',
+          countries: data.map(({ country }) => country),
+          onChange,
+        });
+
+        const $triggerButton = angular.element(getDropdownButton(element));
+
+        // Open the dropdown
+        $triggerButton.triggerHandler('click');
+
+        // Select 5th element (AS)
+        const $itemButton = angular.element(getDropdownItem(element, index));
+        $itemButton.triggerHandler('click');
+        $triggerButton.triggerHandler('click');
+        $timeout.flush();
+
+        expect(onChange).toHaveBeenCalledWith(data[index].country.code);
+      });
+    });
+
     describe('using load', () => {
       it('should load with basic setup', () => {
         const onLoad = jasmine.createSpy();


### PR DESCRIPTION
ref: MANAGER-12502

Title of the Pull Requests
Adding capacity to use value as label for item

Description of the Change
Added a binding to the select component used to map the value bound to the model (using the syntax value as item)
This would allow us to harmonize the uses of select element in the manager
