### PR TITLE
feat(popover): allow custom popover size

### DIFF
--- a/packages/components/field/src/js/field.component.js
+++ b/packages/components/field/src/js/field.component.js
@@ -8,6 +8,7 @@ export default {
     size: '@?',
     errorMessages: '<?',
     labelPopover: '@?',
+    labelPopoverSize: '@?',
     forceErrorDisplay: '<?',
     inline: '<?',
   },

--- a/packages/components/field/src/js/field.html
+++ b/packages/components/field/src/js/field.html
@@ -15,7 +15,8 @@
             ng-if="!!$ctrl.labelPopover"
             oui-popover="{{$ctrl.labelPopover}}"
             oui-popover-id="{{::$ctrl.popoverId}}"
-            oui-popover-placement="right">
+            oui-popover-placement="right"
+            oui-popover-size="{{$ctrl.labelPopoverSize}}">
         </button>
     </div>
     <div class="oui-field__control" ng-transclude></div>

--- a/packages/components/popover/src/js/popover.controller.js
+++ b/packages/components/popover/src/js/popover.controller.js
@@ -145,6 +145,9 @@ export default class PopoverController {
 
   createPopper() {
     this.popperElement.style.minWidth = `${this.triggerElement.offsetWidth}px`;
+    if (this.size) {
+      this.popperElement.style.width = `${this.size}ch`;
+    }
 
     this.popper = new Popper(this.triggerElement, this.popperElement, {
       placement: this.placement,

--- a/packages/components/popover/src/js/popover.directive.js
+++ b/packages/components/popover/src/js/popover.directive.js
@@ -10,6 +10,7 @@ export default () => {
       title: '@?',
       id: '@ouiPopoverId',
       placement: '@?ouiPopoverPlacement',
+      size: '@?ouiPopoverSize',
       scope: '<?ouiPopoverScope',
       template: '@?ouiPopoverTemplate',
       open: '<?ouiPopoverOpen',

--- a/packages/components/popover/src/js/popover.spec.js
+++ b/packages/components/popover/src/js/popover.spec.js
@@ -150,6 +150,17 @@ describe('ouiPopover', () => {
         expect(closeSpy).toHaveBeenCalled();
         expect(closeSpy.calls.count()).toEqual(1);
       });
+
+      it('should create a popover with a fixed size', () => {
+        const component = testUtils.compileTemplate('<div><button class="trigger" oui-popover="foo" oui-popover-size="30"></button></div>');
+
+        $timeout.flush();
+
+        const trigger = angular.element(component[0].querySelector('.trigger')).triggerHandler('click');
+        const popover = trigger.next();
+
+        expect(popover[0].style.width).toEqual('30ch');
+      });
     });
   });
 });


### PR DESCRIPTION
ref: MANAGER-12948

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Allow custom popover width


### Description of the Change

Allow to use a custom fixed width for the popover content. The width is defined by max character number.

### Benefits

Fix some issues when the popover parent element is small, the popover width is to small. Using the new attribute, it is possible to choose a default width.

### Possible Drawbacks

No side effect, nothing change if we don't use the new attribute.

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
