### PR TITLE
feat(components/inline-adder): add rows limit option

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/inline-adder/inline-adder-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/inline-adder/inline-adder-webcomponent.stories.js
@@ -33,6 +33,7 @@ export const Simple = forModule(moduleName).createElement(
     <oui-inline-adder
       tooltip-add="Click here to add an item"
       tooltip-delete="Click here to remove an item"
+      rows-limit=3
       on-add="$ctrl.onAdd(form)"
       on-change="$ctrl.onChange(form)"
       on-remove="$ctrl.onRemove(form)">

--- a/packages/components/inline-adder/README.md
+++ b/packages/components/inline-adder/README.md
@@ -23,13 +23,14 @@ angular.module('myModule', ['oui.inline-adder'])
 
 ## Component `oui-inline-adder`
 
-| Attribute        | Type      | Binding   | One-time binding  | Values            | Default   | Description
-| ----             | ----      | ----      | ----              | ----              | ----      | ----
-| `on-add`         | function  | &         | no                | n/a               | n/a       | handler triggered when a row is added
-| `on-remove`      | function  | &         | no                | n/a               | n/a       | handler triggered when a row is removed
-| `on-change`      | function  | &         | no                | n/a               | n/a       | handler triggered when rows have changed
-| `tooltip-add`    | string    | @?        | yes               | n/a               | n/a       | tooltip to display for the add button
-| `tooltip-delete` | string    | @?        | yes               | n/a               | n/a       | tooltip to display for the delete button
+| Attribute        | Type      | Binding   | One-time binding  | Values            | Default                   | Description
+| ----             | ----      | ----      | ----              | ----              | ----                      | ----
+| `on-add`         | function  | &         | no                | n/a               | n/a                       | handler triggered when a row is added
+| `on-remove`      | function  | &         | no                | n/a               | n/a                       | handler triggered when a row is removed
+| `on-change`      | function  | &         | no                | n/a               | n/a                       | handler triggered when rows have changed
+| `tooltip-add`    | string    | @?        | yes               | n/a               | n/a                       | tooltip to display for the add button
+| `tooltip-delete` | string    | @?        | yes               | n/a               | n/a                       | tooltip to display for the delete button
+| `rows-limit`     | integer   | <?        | yes               | n/a               | `Number.MAX_SAFE_INTEGER` | maximum number of oui-inline-adder-rows
 
 ### Attributes `on-*`
 

--- a/packages/components/inline-adder/src/js/inline-adder.component.js
+++ b/packages/components/inline-adder/src/js/inline-adder.component.js
@@ -10,6 +10,7 @@ export default {
     onRemove: '&',
     tooltipAdd: '@?',
     tooltipDelete: '@?',
+    rowsLimit: '<?',
   },
   controller,
   template,

--- a/packages/components/inline-adder/src/js/inline-adder.controller.js
+++ b/packages/components/inline-adder/src/js/inline-adder.controller.js
@@ -16,6 +16,11 @@ export default class {
     this.forms = [true];
     this.isDisabled = [false];
 
+    this.count = 0;
+    if (typeof this.rowsLimit === 'undefined') {
+      this.rowsLimit = Number.MAX_SAFE_INTEGER;
+    }
+
     addDefaultParameter(this, 'id', `ouiInlineAdderForm${this.$scope.$id}`);
     addDefaultParameter(this, 'name', `ouiInlineAdderForm${this.$scope.$id}`);
   }
@@ -32,10 +37,16 @@ export default class {
 
   onFormSubmit(form, index) {
     if (form.$valid) {
+      this.count += 1;
       this.forms[index] = form;
 
       // Create new instance of form
       this.isDisabled[index] = true;
+
+      if (this.count >= this.rowsLimit) {
+        return;
+      }
+
       this.forms.push(true);
 
       // Callbacks
@@ -48,8 +59,14 @@ export default class {
     // Hide removed form to avoid refreshing ngRepeat
     this.forms[index] = false;
 
+    if (this.count === this.rowsLimit) {
+      // we have unreached the limit, so we need to display again a fresh new empty row
+      this.forms.push(true);
+    }
+
     // Callback
     this.onRemove({ form });
     this.onFormsChange();
+    this.count -= 1;
   }
 }

--- a/packages/components/inline-adder/src/js/inline-adder.spec.js
+++ b/packages/components/inline-adder/src/js/inline-adder.spec.js
@@ -144,6 +144,35 @@ describe('ouiInlineAdder', () => {
     });
 
     describe('oui-inline-adder-row', () => {
+      it('should have a row limit', () => {
+        const element = TestUtils.compileTemplate(`
+                    <oui-inline-adder rows-limit=3>
+                        <oui-inline-adder-row>
+                            <oui-inline-adder-field>
+                                <oui-field label="Field 1">
+                                    <input type="text" class="oui-input" name="field1" required>
+                                </oui-field>
+                            </oui-inline-adder-field>
+                        </oui-inline-adder-row>
+                    </oui-inline-adder>`);
+
+        const form = angular.element(element.find('form')[0]);
+
+        form.triggerHandler('submit');
+        expect(element.find('form').length).toBe(2);
+
+        form.triggerHandler('submit');
+        expect(element.find('form').length).toBe(3);
+
+        form.triggerHandler('submit');
+        expect(element.find('form').length).toBe(3); // limit reached
+
+        const newform = angular.element(element.find('form')[0]);
+        const newfooter = angular.element(newform.find('footer')[0]);
+        const newbutton = angular.element(newfooter.find('button')[0]);
+        newbutton.triggerHandler('click');
+      });
+
       it('should have a default classname', () => {
         const element = TestUtils.compileTemplate(`
                     <oui-inline-adder>


### PR DESCRIPTION
## Title of the Pull Requests
Add rows limit option to existing inline-adder component

### Description of the Change

Add rows limit option to existing inline-adder component

### Benefits

Prevent customer to create a useless huge number of rows that will make his web browser crashing.

### Possible Drawbacks

None

### Applicable Issues

MANAGER-13020
