### PR TITLE
feat(components.file): add an onremove callback on file input

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
@@ -175,12 +175,12 @@ export const EventHandling = forModule(moduleName).createElement(
 
         onSelect(model) {
           const plural = model.length > 1;
-          this.message = `You select a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
+          this.message = `You've selected a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
         }
 
         onRemove(model) {
           const plural = model.length > 1;
-          this.message = `You remove a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
+          this.message = `You've removed a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
         }
       })(),
     },

--- a/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
@@ -4,6 +4,7 @@ import { forModule } from 'storybook-addon-angularjs';
 import Field from '@ovh-ux/ui-kit.field';
 import File from '@ovh-ux/ui-kit.file';
 import FormActions from '@ovh-ux/ui-kit.form-actions';
+import Message from '@ovh-ux/ui-kit.message';
 
 import readme from '@ovh-ux/ui-kit.file/README.md';
 import { compileTemplate } from '../../../../src/utils';
@@ -16,6 +17,7 @@ angular.module(moduleName, [
   // For examples
   Field,
   FormActions,
+  Message,
 ]);
 
 export default {
@@ -147,3 +149,42 @@ export const Validation = forModule(moduleName).createElement(
     },
   ),
 );
+
+export const EventHandling = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-message
+      type="info"
+      ng-if="$ctrl.message">
+      {{$ctrl.message}}
+    </oui-message>
+    <oui-file
+      disabled="$ctrl.disabled"
+      model="$ctrl.model"
+      multiple
+      on-select="$ctrl.onSelect(modelValue)"
+      on-remove="$ctrl.onRemove(modelValue)"
+    >
+    </oui-file>
+    `,
+    {
+      $ctrl: new (class {
+        constructor() {
+          this.message = '';
+        }
+
+        onSelect(model) {
+          const plural = model.length > 1;
+          this.message = `You select a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
+        }
+
+        onRemove(model) {
+          const plural = model.length > 1;
+          this.message = `You remove a file ! Currently ${model.length} file${plural ? 's' : ''} selected`;
+        }
+      })(),
+    },
+  ),
+);
+
+EventHandling.storyName = 'Trigger event on selection and deletion';

--- a/packages/components/file/README.md
+++ b/packages/components/file/README.md
@@ -51,4 +51,4 @@ angular.module('myModule', ['oui.file'])
 | `droparea`        | boolean           | <?        | yes               | `true`, `false`   | `false`   | enable a drop area to drag files
 | `preview`         | boolean           | <?        | yes               | `true`, `false`   | `false`   | show preview of image files (works only with `image/*` files.)
 | `on-select`       | function          | &         | no                | n/a               | n/a       | handler triggered when files are selected
-| `on-remove`       | function          | &         | no                | n/a               | n/a       | handler triggered when attachment is removed
+| `on-remove`       | function          | &         | no                | n/a               | n/a       | handler triggered when an attachment is removed

--- a/packages/components/file/README.md
+++ b/packages/components/file/README.md
@@ -51,3 +51,4 @@ angular.module('myModule', ['oui.file'])
 | `droparea`        | boolean           | <?        | yes               | `true`, `false`   | `false`   | enable a drop area to drag files
 | `preview`         | boolean           | <?        | yes               | `true`, `false`   | `false`   | show preview of image files (works only with `image/*` files.)
 | `on-select`       | function          | &         | no                | n/a               | n/a       | handler triggered when files are selected
+| `on-remove`       | function          | &         | no                | n/a               | n/a       | handler triggered when attachment is removed

--- a/packages/components/file/src/js/file.component.js
+++ b/packages/components/file/src/js/file.component.js
@@ -18,6 +18,7 @@ export default {
     droparea: '<?',
     preview: '<?',
     onSelect: '&',
+    onRemove: '&',
   },
   controller,
   template,

--- a/packages/components/file/src/js/file.controller.js
+++ b/packages/components/file/src/js/file.controller.js
@@ -103,12 +103,14 @@ export default class {
   removeFile(file) {
     if (angular.isArray(this.model)) {
       remove(this.model, (item) => item === file);
+      this.onRemove({ modelValue: this.model });
     }
   }
 
   resetFile() {
     this.model = undefined;
     this.fileSelector[0].value = '';
+    this.onRemove({ modelValue: this.model });
 
     if (this.form && this.form[this.name]) {
       this.form[this.name].$setValidity('maxsize', true);

--- a/packages/components/file/src/js/file.spec.js
+++ b/packages/components/file/src/js/file.spec.js
@@ -190,15 +190,20 @@ describe('ouiFile', () => {
       let element;
       let controller;
       let onSelectSpy;
+      let onRemoveSpy;
 
       beforeEach(() => {
         onSelectSpy = jasmine.createSpy('onSelectSpy');
+        onRemoveSpy = jasmine.createSpy('onRemoveSpy');
         element = TestUtils.compileTemplate(`
                 <oui-file
                     model="$ctrl.model"
-                    on-select="$ctrl.onSelectSpy(modelValue)">
+                    on-select="$ctrl.onSelectSpy(modelValue)"
+                    on-remove="$ctrl.onRemoveSpy(modelValue)"
+                >
                 </oui-file>`, {
           onSelectSpy,
+          onRemoveSpy,
         });
         controller = element.controller('ouiFile');
 
@@ -254,6 +259,7 @@ describe('ouiFile', () => {
         controller.addFiles(mockFiles);
         controller.removeFile(mockFile);
         expect(controller.model.length).toBe(0);
+        expect(onRemoveSpy).toHaveBeenCalledWith(controller.model);
       });
     });
 


### PR DESCRIPTION
## Add an onremove callback on file input
Ref: UK-196

### Description of the Change

Currently, there isn't a trigger to know if a user remove an attachment on the file input component. To handle that. I add a onRemove callback to call when an attachment is removed.

### Benefits

Be able to check the attachment removal without using a watch or watchCollection

### Possible Drawbacks

<!-- optional -->
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- optional -->
<!-- Enter any applicable Issues here -->
