### PR TITLE
fix(file): added file extension validation

### DIFF
--- a/packages/components/field/src/js/field.provider.js
+++ b/packages/components/field/src/js/field.provider.js
@@ -14,6 +14,7 @@ export default class {
         minlength: 'Too short ({{minlength}} characters min).',
         maxlength: 'Too high ({{maxlength}} characters max).',
         maxsize: 'This file exceeds the size limit',
+        type: 'This file extension is not supported',
         pattern: 'Invalid format.',
       },
     };


### PR DESCRIPTION
## Title of the Pull Requests
Fix File component extension validation


### Description of the Change

Added the file extension validation
Added a parsing for the accept attribute (to avoid validation based on incorrect values)
Added unit tests

### Benefits

Better user experience by adding a visual hint that a file with an invalid extension is invalid

### Possible Drawbacks

Some light slow down on a performance side (on the component initialization and after selecting a file) as we cycle through the MIME types / extensions to parse them (component initialization) and validate input extension (file selection)

### Applicable Issues

When a user select a file with an invalid extension, the error is not displayed on the file "preview" and the form is not considered as invalid.
