### PR TITLE
fix(file): cleanup file error when none is present

### DIFF
--- a/packages/components/file/src/js/file.controller.js
+++ b/packages/components/file/src/js/file.controller.js
@@ -36,7 +36,7 @@ export default class {
       if (this.accept) {
         const [fileType, fileExtension] = file.type.split('/');
         const acceptedTypes = this.accept.split(',');
-        file.errors.type = !acceptedTypes.some((acceptedType) => {
+        const hasTypeError = !acceptedTypes.some((acceptedType) => {
           const [type, extension] = acceptedType.split('/');
           if (extension) {
             const isTypeValid = type === '*' || type.toLowerCase() === fileType.toLowerCase();
@@ -45,6 +45,9 @@ export default class {
           }
           return type === '*' || type.replace('.', '').toLowerCase() === fileExtension.toLowerCase();
         });
+        if (hasTypeError) {
+          file.errors.type = true;
+        }
       }
 
       // Set form validation

--- a/packages/components/file/src/js/file.spec.js
+++ b/packages/components/file/src/js/file.spec.js
@@ -328,14 +328,18 @@ describe('ouiFile', () => {
         expect(controller.form[name].$dirty).toBeFalsy();
 
         controller.maxsize = 200000;
-        controller.checkFileValidity(mockFile);
+        let file = controller.checkFileValidity(mockFile);
         expect(controller.form[name].$error.maxsize).toBeFalsy();
+        expect(file.errors).toBeUndefined();
 
         expect(controller.form[name].$dirty).toBeTruthy();
 
         controller.maxsize = 100000;
-        controller.checkFileValidity(mockFile);
+        file = controller.checkFileValidity(mockFile);
         expect(controller.form[name].$error.maxsize).toBeTruthy();
+        expect(file.errors).toBeDefined();
+        expect(file.errors.maxsize).toBeDefined();
+        expect(file.errors.type).toBeUndefined();
 
         // Valid extension tests
         controller.accept = 'image/png';
@@ -351,13 +355,19 @@ describe('ouiFile', () => {
         expect(controller.form[name].$error.type).toBeFalsy();
 
         controller.accept = '.png';
-        controller.checkFileValidity(mockFile);
+        file = controller.checkFileValidity(mockFile);
         expect(controller.form[name].$error.type).toBeFalsy();
+        expect(file.errors).toBeDefined();
+        expect(file.errors.maxsize).toBeDefined();
+        expect(file.errors.type).toBeUndefined();
 
         // Invalid extension tests
         controller.accept = 'image/jpeg';
-        controller.checkFileValidity(mockFile);
+        file = controller.checkFileValidity(mockFile);
         expect(controller.form[name].$error.type).toBeTruthy();
+        expect(file.errors).toBeDefined();
+        expect(file.errors.maxsize).toBeDefined();
+        expect(file.errors.type).toBeDefined();
 
         controller.resetFile();
         expect(controller.form[name].$error.maxsize).toBeFalsy();


### PR DESCRIPTION
## Title of the Pull Requests
Cleanup file error when none is present


### Description of the Change

Setting up the same error management for maxsize and type errors
Added some tests to cover the Applicable Issues

### Benefits
Better user experience by removing an incorrect visual hint that a valid file uploaded after an invalid one is invalid

### Applicable Issues
When a user select a file with an invalid extension and then a valid file, the valid file appears as invalid.
