### PR TITLE
fix(file): display error message for multiple files

### DIFF
--- a/packages/components/file/src/js/file.controller.js
+++ b/packages/components/file/src/js/file.controller.js
@@ -39,11 +39,11 @@ export default class {
         const hasTypeError = !acceptedTypes.some((acceptedType) => {
           const [type, extension] = acceptedType.split('/');
           if (extension) {
-            const isTypeValid = type === '*' || type.toLowerCase() === fileType.toLowerCase();
-            const isExtensionValid = extension === '*' || extension.toLowerCase() === fileExtension.toLowerCase();
+            const isTypeValid = type === '*' || type.toLowerCase() === fileType?.toLowerCase();
+            const isExtensionValid = extension === '*' || extension.toLowerCase() === fileExtension?.toLowerCase();
             return isTypeValid && isExtensionValid;
           }
-          return type === '*' || type.replace('.', '').toLowerCase() === fileExtension.toLowerCase();
+          return type === '*' || type.replace('.', '').toLowerCase() === fileExtension?.toLowerCase();
         });
         if (hasTypeError) {
           file.errors.type = true;

--- a/packages/components/file/src/js/file.html
+++ b/packages/components/file/src/js/file.html
@@ -142,11 +142,15 @@
                     <span class="oui-file-ellipsis__size" ng-bind="file.infos.size"></span>
                 </span>
                 <span class="oui-file-attachments__error"
-                    ng-if="file.errors && file.errors.maxsize"
+                    ng-if="file.errors.maxsizeError"
                     ng-bind="::$ctrl.translations.maxsizeError">
                 </span>
                 <span class="oui-file-attachments__error"
-                    ng-if="file.errors && file.errors.notSingle"
+                    ng-if="file.errors.type"
+                    ng-bind="::$ctrl.translations.typeError">
+                </span>
+                <span class="oui-file-attachments__error"
+                    ng-if="file.errors.notSingle"
                     ng-bind="::$ctrl.translations.notSingleError">
                 </span>
             </span>

--- a/packages/components/file/src/js/file.provider.js
+++ b/packages/components/file/src/js/file.provider.js
@@ -14,6 +14,7 @@ export default class {
       maxsizeError: 'This file exceeds the size limit',
       notSingleError: 'You can only add one file',
       removeFile: 'Remove file from selector',
+      typeError: 'This file extension is not supported',
     };
 
     this.units = [


### PR DESCRIPTION
## Title of the Pull Requests
Fix File component extension error display


### Description of the Change

Removed condition to display errors

### Benefits

Better user experience by adding information regarding the invalid extension error for a file 

### Possible Drawbacks

-

### Applicable Issues

When a user select a file with an invalid extension, the file appear in error but without any explanation as to why the file is invalid.