### PR TITLE
fix(file): handle multiple boolean on droparea

### DIFF
--- a/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
+++ b/packages/apps/workshop/stories/design-system/components/file/file-webcomponent.stories.js
@@ -94,6 +94,7 @@ export const DragDropArea = forModule(moduleName).createElement(
       disabled="$ctrl.disabled"
       maxsize="150000"
       model="$ctrl.model"
+      multiple
       droparea>
     </oui-file>`,
     {
@@ -106,6 +107,25 @@ export const DragDropArea = forModule(moduleName).createElement(
 
 DragDropArea.storyName = 'Drag & Drop area';
 
+export const DragDropAreaSingle = forModule(moduleName).createElement(
+  () => compileTemplate(
+    `
+    <oui-file
+      disabled="$ctrl.disabled"
+      maxsize="150000"
+      model="$ctrl.model"
+      droparea>
+    </oui-file>`,
+    {
+      $ctrl: {
+        disabled: boolean('Disabled state', false),
+      },
+    },
+  ),
+);
+
+DragDropAreaSingle.storyName = 'Drag & Drop area single file';
+
 export const DragDropWithPreview = forModule(moduleName).createElement(
   () => compileTemplate(
     `
@@ -113,6 +133,7 @@ export const DragDropWithPreview = forModule(moduleName).createElement(
       disabled="$ctrl.disabled"
       maxsize="150000"
       model="$ctrl.model"
+      multiple
       droparea
       preview>
     </oui-file>`,

--- a/packages/components/file/src/js/file.html
+++ b/packages/components/file/src/js/file.html
@@ -94,7 +94,8 @@
         <span class="oui-icon oui-icon-file" aria-hidden="true"></span>
     </div>
     <div class="oui-file-droparea__text" >
-        <span ng-bind="::$ctrl.translations.dropArea"></span>
+        <span ng-if="$ctrl.multiple" ng-bind="::$ctrl.translations.dropArea"></span>
+        <span ng-if="!$ctrl.multiple" ng-bind="::$ctrl.translations.dropAreaSingle"></span>
         <button class="oui-link"
             type="button"
             ng-bind="::$ctrl.translations.dropAreaSelector"
@@ -143,6 +144,10 @@
                 <span class="oui-file-attachments__error"
                     ng-if="file.errors && file.errors.maxsize"
                     ng-bind="::$ctrl.translations.maxsizeError">
+                </span>
+                <span class="oui-file-attachments__error"
+                    ng-if="file.errors && file.errors.notSingle"
+                    ng-bind="::$ctrl.translations.notSingleError">
                 </span>
             </span>
             <button class="oui-file-attachments__remove oui-icon oui-icon-close"

--- a/packages/components/file/src/js/file.provider.js
+++ b/packages/components/file/src/js/file.provider.js
@@ -6,11 +6,13 @@ export default class {
     this.translations = {
       attachmentsHeading: 'Attachment(s)',
       dropArea: 'Attach document(s) by drap and drop or',
+      dropAreaSingle: 'Attach a document by drap and drop or',
       dropAreaSelector: 'select a file',
       filePlaceholder: 'Select a file...',
       fileSelector: 'Select file',
       filesSelector: 'Select file(s)...',
       maxsizeError: 'This file exceeds the size limit',
+      notSingleError: 'You can only add one file',
       removeFile: 'Remove file from selector',
     };
 


### PR DESCRIPTION
## MANAGER-15187

### Handle the 'multiple' boolean with drop area

### Benefits

Be able to have a drop area component that handle errors when we want an unique file and user want to upload more.
Also, handle singular and plural on the label for a better understanding.
